### PR TITLE
docs & dashboard: setup guide, content style guide, empty-state copy system, and saved history filters

### DIFF
--- a/components/features/employees/EmployeeDirectory.tsx
+++ b/components/features/employees/EmployeeDirectory.tsx
@@ -80,17 +80,7 @@ function EmployeeDirectory() {
           </div>
         ) : filtered.length === 0 ? (
           <EmptyState
-            icon={Users}
-            title={
-              statusFilter === "all"
-                ? "No employees yet"
-                : `No ${statusFilter} employees`
-            }
-            description={
-              statusFilter === "all"
-                ? "Add employees to get started with payroll."
-                : `There are no employees with ${statusFilter} status.`
-            }
+            screen={statusFilter === "all" ? "employees" : "employees-filtered"}
             action={
               statusFilter !== "all"
                 ? { label: "View all employees", onClick: () => setStatusFilter("all") }

--- a/components/features/transactions/TransactionHistory.tsx
+++ b/components/features/transactions/TransactionHistory.tsx
@@ -1,15 +1,21 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import {
   ArrowUpRight,
   ArrowDownLeft,
   Download,
   Filter,
   X,
+  Save,
+  Bookmark,
+  Pencil,
+  Trash2,
+  Check,
 } from "lucide-react";
 import { MOCK_TRANSACTIONS, MOCK_EMPLOYEES } from "@/lib/api/mockData";
 import type { PayrollTransaction } from "@/types";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 
 type StatusFilter = "all" | "verified" | "pending" | "failed";
 
@@ -21,6 +27,13 @@ interface Filters {
   payrollRun: string;
 }
 
+interface SavedView {
+  id: string;
+  name: string;
+  filters: Filters;
+  createdAt: string;
+}
+
 const initialFilters: Filters = {
   status: "all",
   employee: "",
@@ -28,6 +41,10 @@ const initialFilters: Filters = {
   dateTo: "",
   payrollRun: "",
 };
+
+function generateViewId(): string {
+  return `sv_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+}
 
 function toCsvRow(values: string[]): string {
   return values
@@ -46,7 +63,7 @@ function exportToCsv(rows: PayrollTransaction[]): string {
         tx.id,
         new Date(tx.createdAt).toLocaleDateString(),
         tx.status,
-        `$${tx.totalAmount.toLocaleString()}`,
+        `${tx.totalAmount.toLocaleString()}`,
         String(tx.employeeCount),
         tx.txHash ?? "N/A",
       ]),
@@ -68,6 +85,15 @@ function downloadCsv(csv: string, filename: string) {
 function TransactionHistory() {
   const [filters, setFilters] = useState<Filters>(initialFilters);
   const [showFilters, setShowFilters] = useState(false);
+  const [savedViews, setSavedViews] = useLocalStorage<SavedView[]>(
+    "zk-payroll-saved-views",
+    [],
+  );
+  const [showSavedViews, setShowSavedViews] = useState(false);
+  const [savingName, setSavingName] = useState("");
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [editingViewId, setEditingViewId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   const filtered = useMemo(() => {
     let results = [...MOCK_TRANSACTIONS];
@@ -118,6 +144,65 @@ function TransactionHistory() {
 
   const clearFilters = () => setFilters(initialFilters);
 
+  // ── Saved views handlers ────────────────────────────────────
+
+  const handleSaveView = useCallback(() => {
+    const name = savingName.trim() || `View ${savedViews.length + 1}`;
+    const newView: SavedView = {
+      id: generateViewId(),
+      name,
+      filters: { ...filters },
+      createdAt: new Date().toISOString(),
+    };
+    setSavedViews((prev) => [...prev, newView]);
+    setSavingName("");
+    setShowSaveDialog(false);
+  }, [savingName, filters, savedViews.length, setSavedViews]);
+
+  const handleApplyView = useCallback(
+    (view: SavedView) => {
+      setFilters({ ...view.filters });
+      setShowSavedViews(false);
+    },
+    [],
+  );
+
+  const handleDeleteView = useCallback(
+    (id: string) => {
+      setSavedViews((prev) => prev.filter((v) => v.id !== id));
+    },
+    [setSavedViews],
+  );
+
+  const handleStartRename = useCallback(
+    (view: SavedView) => {
+      setEditingViewId(view.id);
+      setRenameValue(view.name);
+    },
+    [],
+  );
+
+  const handleFinishRename = useCallback(
+    (id: string) => {
+      const name = renameValue.trim();
+      if (!name) {
+        setEditingViewId(null);
+        return;
+      }
+      setSavedViews((prev) =>
+        prev.map((v) => (v.id === id ? { ...v, name } : v)),
+      );
+      setEditingViewId(null);
+      setRenameValue("");
+    },
+    [renameValue, setSavedViews],
+  );
+
+  const hasFiltersApplied = activeFilterCount > 0;
+  const currentView = savedViews.find(
+    (v) => JSON.stringify(v.filters) === JSON.stringify(filters),
+  );
+
   return (
     <section aria-labelledby="transaction-history-heading">
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
@@ -129,25 +214,110 @@ function TransactionHistory() {
             Transaction History
           </h3>
           <div className="flex items-center gap-2">
+            {/* Saved Views dropdown */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setShowSavedViews(!showSavedViews)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  showSavedViews
+                    ? "bg-indigo-50 text-indigo-700"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+                aria-expanded={showSavedViews}
+                aria-controls="saved-views-panel"
+              >
+                <Bookmark className="w-3.5 h-3.5" />
+                Saved Views
+                {savedViews.length > 0 && (
+                  <span className="ml-1 px-1.5 py-0.5 text-xs bg-gray-600 text-white rounded-full">
+                    {savedViews.length}
+                  </span>
+                )}
+              </button>
+              {showSavedViews && (
+                <div
+                  id="saved-views-panel"
+                  role="menu"
+                  className="absolute right-0 mt-2 w-72 rounded-xl bg-white border border-gray-200 shadow-xl z-50 py-2"
+                >
+                  <p className="px-4 py-1 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Saved Views
+                  </p>
+                  {savedViews.length === 0 ? (
+                    <p className="px-4 py-3 text-sm text-gray-400 italic">
+                      No saved views yet.
+                    </p>
+                  ) : (
+                    savedViews.map((view) => (
+                      <div
+                        key={view.id}
+                        role="menuitem"
+                        className="flex items-center gap-2 px-4 py-2 hover:bg-gray-50 group"
+                      >
+                        {editingViewId === view.id ? (
+                          <div className="flex items-center gap-1 flex-1 min-w-0">
+                            <input
+                              type="text"
+                              value={renameValue}
+                              onChange={(e) => setRenameValue(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") handleFinishRename(view.id);
+                                if (e.key === "Escape") setEditingViewId(null);
+                              }}
+                              className="flex-1 min-w-0 rounded border border-gray-300 px-2 py-1 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                              autoFocus
+                            />
+                            <button
+                              type="button"
+                              onClick={() => handleFinishRename(view.id)}
+                              className="p-1 text-green-600 hover:text-green-800"
+                              aria-label="Save name"
+                            >
+                              <Check className="w-3.5 h-3.5" />
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => handleApplyView(view)}
+                            className={`flex-1 text-left text-sm truncate ${
+                              currentView?.id === view.id
+                                ? "font-semibold text-indigo-700"
+                                : "text-gray-700"
+                            }`}
+                          >
+                            {view.name}
+                          </button>
+                        )}
+                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            type="button"
+                            onClick={() => handleStartRename(view)}
+                            className="p-1 text-gray-400 hover:text-gray-600"
+                            aria-label={`Rename ${view.name}`}
+                          >
+                            <Pencil className="w-3 h-3" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteView(view.id)}
+                            className="p-1 text-gray-400 hover:text-red-600"
+                            aria-label={`Delete ${view.name}`}
+                          >
+                            <Trash2 className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+
             <button
               type="button"
               onClick={() => setShowFilters(!showFilters)}
-              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                showFilters
-                  ? "bg-indigo-50 text-indigo-700"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-              }`}
-              aria-expanded={showFilters}
-              aria-controls="filter-panel"
-            >
-              <Filter className="w-3.5 h-3.5" />
-              Filters
-              {activeFilterCount > 0 && (
-                <span className="ml-1 px-1.5 py-0.5 text-xs bg-indigo-600 text-white rounded-full">
-                  {activeFilterCount}
-                </span>
-              )}
-            </button>
             <button
               type="button"
               onClick={handleExport}
@@ -275,6 +445,77 @@ function TransactionHistory() {
           </div>
         )}
 
+        {/* ── Active filter bar with save button ──────────────────── */}
+        {hasFiltersApplied && (
+          <div className="px-6 py-2 bg-indigo-50 border-b flex items-center justify-between">
+            <p className="text-xs text-indigo-700">
+              {activeFilterCount} filter{activeFilterCount > 1 ? "s" : ""} active
+              {currentView && (
+                <span className="ml-1">
+                  — matching view: <strong>{currentView.name}</strong>
+                </span>
+              )}
+            </p>
+            <div className="flex items-center gap-2">
+              {showSaveDialog ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    type="text"
+                    value={savingName}
+                    onChange={(e) => setSavingName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleSaveView();
+                      if (e.key === "Escape") {
+                        setShowSaveDialog(false);
+                        setSavingName("");
+                      }
+                    }}
+                    placeholder="View name..."
+                    className="w-40 rounded border border-indigo-300 px-2 py-1 text-xs focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                    autoFocus
+                  />
+                  <button
+                    type="button"
+                    onClick={handleSaveView}
+                    className="p-1 text-indigo-600 hover:text-indigo-800"
+                    aria-label="Save view"
+                  >
+                    <Check className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowSaveDialog(false);
+                      setSavingName("");
+                    }}
+                    className="p-1 text-gray-400 hover:text-gray-600"
+                    aria-label="Cancel"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowSaveDialog(true)}
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
+                >
+                  <Save className="w-3 h-3" />
+                  Save as view
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-gray-600 hover:bg-gray-200 transition-colors"
+              >
+                <X className="w-3 h-3" />
+                Clear all
+              </button>
+            </div>
+          </div>
+        )}
+
         <table className="w-full text-left">
           <caption className="sr-only">
             Payroll transactions with filtering and export
@@ -320,7 +561,9 @@ function TransactionHistory() {
                   colSpan={5}
                   className="px-6 py-8 text-center text-sm text-gray-500"
                 >
-                  No transactions match the current filters.
+                  {hasFiltersApplied
+                    ? "No transactions match the current filters. Try broadening your filter criteria."
+                    : "No transactions yet. Process a payroll run to populate the transaction history."}
                 </td>
               </tr>
             ) : (

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,28 +1,163 @@
-import { type LucideIcon } from "lucide-react";
+"use client";
 
-interface EmptyStateProps {
+import { type LucideIcon } from "lucide-react";
+import {
+  Users,
+  Receipt,
+  Key,
+  Building2,
+  Search,
+  Landmark,
+  History,
+} from "lucide-react";
+
+// ─── Screen-specific empty-state definitions ─────────────────────
+// These templates centralize copy so every screen reuses the same
+// patterns. Add new entries when a new feature screen is created.
+
+export type EmptyStateScreen =
+  | "employees"
+  | "employees-filtered"
+  | "payroll"
+  | "history"
+  | "history-filtered"
+  | "audit"
+  | "audit-filtered"
+  | "treasury"
+  | "company"
+  | "generic"
+  | "search";
+
+export interface EmptyStateDefinition {
   icon: LucideIcon;
   title: string;
   description: string;
+  actionLabel?: string;
+}
+
+/**
+ * Central catalog of empty-state copy.
+ * Every screen maps to a definition to keep messaging consistent.
+ */
+export const EMPTY_STATE_COPY: Record<EmptyStateScreen, EmptyStateDefinition> =
+  {
+    employees: {
+      icon: Users,
+      title: "No employees yet",
+      description: "Add employees to get started with payroll.",
+      actionLabel: "Add employee",
+    },
+    "employees-filtered": {
+      icon: Users,
+      title: "No employees match this filter",
+      description: "Try adjusting the status filter to see more results.",
+      actionLabel: "View all employees",
+    },
+    payroll: {
+      icon: Receipt,
+      title: "No payroll runs yet",
+      description: "Process your first payroll to see it here.",
+      actionLabel: "Start payroll",
+    },
+    history: {
+      icon: History,
+      title: "No transactions yet",
+      description: "Process a payroll run to populate the transaction history.",
+      actionLabel: "Process payroll",
+    },
+    "history-filtered": {
+      icon: Search,
+      title: "No transactions match the current filters",
+      description: "Try broadening your filter criteria to see more results.",
+      actionLabel: "Clear filters",
+    },
+    audit: {
+      icon: Key,
+      title: "No view keys generated",
+      description:
+        "Generate a view key to grant auditor access to payroll records.",
+      actionLabel: "Generate view key",
+    },
+    "audit-filtered": {
+      icon: Key,
+      title: "No inactive view keys",
+      description: "All generated keys are currently active.",
+    },
+    treasury: {
+      icon: Landmark,
+      title: "No treasury activity",
+      description: "Treasury transactions will appear once payroll runs start.",
+    },
+    company: {
+      icon: Building2,
+      title: "Company not set up",
+      description:
+        "Complete your company setup to start managing payroll on Stellar.",
+      actionLabel: "Set up now",
+    },
+    generic: {
+      icon: Search,
+      title: "Nothing here yet",
+      description: "Data will appear once you start using this feature.",
+    },
+    search: {
+      icon: Search,
+      title: "No results found",
+      description: "Try a different search term or adjust your filters.",
+    },
+  };
+
+interface EmptyStateProps {
+  /** Use a screen key for pre-defined copy, or override individual fields. */
+  screen?: EmptyStateScreen;
+  icon?: LucideIcon;
+  title?: string;
+  description?: string;
   action?: {
     label: string;
     onClick: () => void;
   };
 }
 
-function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
+function EmptyState({
+  screen,
+  icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  // Resolve from screen preset when provided, then allow overrides
+  const preset = screen ? EMPTY_STATE_COPY[screen] : null;
+
+  const resolvedIcon = icon ?? preset?.icon ?? EMPTY_STATE_COPY.generic.icon;
+  const resolvedTitle = title ?? preset?.title ?? EMPTY_STATE_COPY.generic.title;
+  const resolvedDescription =
+    description ?? preset?.description ?? EMPTY_STATE_COPY.generic.description;
+  const resolvedAction = action ?? (preset?.actionLabel
+    ? { label: preset.actionLabel, onClick: () => {} }
+    : undefined);
+
+  const IconComponent = resolvedIcon;
+
   return (
     <div className="text-center py-12">
-      <Icon className="w-10 h-10 text-gray-400 mx-auto mb-3" aria-hidden="true" />
-      <h3 className="text-sm font-semibold text-gray-900 mb-1">{title}</h3>
-      <p className="text-sm text-gray-500 mb-4">{description}</p>
-      {action && (
+      <IconComponent
+        className="w-10 h-10 text-gray-400 mx-auto mb-3"
+        aria-hidden="true"
+      />
+      <h3 className="text-sm font-semibold text-gray-900 mb-1">
+        {resolvedTitle}
+      </h3>
+      <p className="text-sm text-gray-500 mb-4 max-w-sm mx-auto">
+        {resolvedDescription}
+      </p>
+      {resolvedAction && resolvedAction.label && (
         <button
           type="button"
-          onClick={action.onClick}
+          onClick={resolvedAction.onClick}
           className="px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
         >
-          {action.label}
+          {resolvedAction.label}
         </button>
       )}
     </div>
@@ -30,3 +165,4 @@ function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps)
 }
 
 export default EmptyState;
+export { EMPTY_STATE_COPY };

--- a/docs/CONTENT_STYLE_GUIDE.md
+++ b/docs/CONTENT_STYLE_GUIDE.md
@@ -1,0 +1,128 @@
+# Content Style Guide
+
+A lightweight guide for writing consistent UX copy across the ZK Payroll Dashboard.
+
+## 🎯 Tone & Voice
+
+| Attribute | Standard |
+|-----------|----------|
+| **Tone** | Professional, reassuring, and direct |
+| **Voice** | Active voice, second-person ("you") when addressing the user |
+| **Sentence length** | Keep under 25 words where possible |
+| **Jargon** | Minimize; explain when necessary |
+| **Punctuation** | Use sentence case everywhere (no title case for UI labels) |
+
+### Examples
+
+| ✅ Do | ❌ Don't |
+|-------|----------|
+| "Connect your wallet to get started" | "Connect Wallet To Get Started" |
+| "No employees yet" | "You Have No Employees" |
+| "Add employees to get started with payroll." | "Employee Addition Required for Payroll Initiation" |
+| "Dashboard data will appear after company setup is complete." | "Dashboard Data Requires Company Configuration" |
+
+## 🏷 Status Labels
+
+Use these exact labels consistently across the app.
+
+| Status | Usage | Badge Style |
+|--------|-------|-------------|
+| `verified` | Payroll transaction verified on-chain | Green (`bg-green-100 text-green-800`) |
+| `pending` | Transaction submitted but not yet confirmed | Yellow (`bg-yellow-100 text-yellow-800`) |
+| `failed` | Transaction rejected by the network | Red (`bg-red-100 text-red-800`) |
+| `active` | Employee currently enrolled and paid | Green (`bg-green-100 text-green-800`) |
+| `inactive` | Employee no longer receiving payroll | Gray (`bg-gray-100 text-gray-600`) |
+| `pending` (employee) | New employee awaiting first payment | Yellow (`bg-yellow-100 text-yellow-800`) |
+
+### Status Wording Rules
+
+- **Always lowercase** in status badges
+- **Never** truncate status text
+- **Never** add icons inside badges
+- Use the exact strings above — no synonyms ("confirmed" → use "verified")
+
+## ⚠️ Error Messages
+
+### Pattern
+
+```
+[Action] failed: [specific reason]. [Optional next step].
+```
+
+### Message Catalog
+
+| Scenario | Error Copy |
+|----------|------------|
+| Wallet connection failure | "Failed to connect wallet. Ensure Freighter is unlocked and on Testnet." |
+| Proof generation failure | "Proof generation failed: circuit constraint mismatch. Please retry." |
+| Transaction submission failure | "Submission failed: network timeout. The transaction may still be processing." |
+| Unknown error | "An unexpected error occurred. Please try again." |
+| Empty search results | "No results match the current filters." |
+| Missing wallet | "Freighter not detected. Install the extension and refresh." |
+
+### Error Tone Rules
+
+- **Do not blame the user** — avoid "You entered..." or "Your wallet..."
+- **Do not over-technical** — avoid raw error codes in user-facing messages
+- **Do provide a next step** whenever possible
+- **Do use "we"** for system-side issues ("We couldn't verify the proof")
+
+## 🔔 Success & Confirmation Messages
+
+| Scenario | Confirmation Copy |
+|----------|-------------------|
+| Wallet connected | "Wallet connected" (announced via screen reader) |
+| Proof generated | "Proof generated successfully" |
+| Payroll submitted | "Payroll submitted successfully — Transaction submitted to the Stellar network." |
+| View key generated | "View key generated — Auditor access has been granted." |
+| View key revoked | "View key revoked — Auditor access has been immediately revoked." |
+| CSV exported | (No toast — silent success) |
+
+## ⚡ Warning Messages
+
+| Scenario | Warning Copy |
+|----------|--------------|
+| Company not set up | "Company setup required — Complete your company setup to start managing payroll." |
+| Action required (pending approvals) | "Action required" |
+| Low treasury balance | "Treasury balance is low — Fund your account before the next pay run." |
+| Expiring view key | "View key expires soon — Renew before [date] to avoid audit interruption." |
+
+## 📖 Core Terminology
+
+Use these terms consistently throughout the dashboard.
+
+| Term | Definition | Usage Notes |
+|------|------------|-------------|
+| **Payroll** | The process of paying employees for a given period | Not "salary run" or "pay cycle" |
+| **Payroll run** | A single batch of payments in one period | |
+| **Proof** | A zero-knowledge proof verifying payroll correctness | Short for "ZK proof" |
+| **Proof generation** | The process of computing a ZK proof | |
+| **View key** | A cryptographic key granting auditor read access | Not "audit key" or "disclosure key" |
+| **Auditor** | An external party reviewing payroll records | |
+| **Treasury** | The Stellar account holding payroll funds | |
+| **Commitment** | A cryptographic commitment hiding a salary amount | |
+| **Testnet** | The Stellar test network for development | Always capitalize "Testnet" |
+| **Freighter** | The Stellar wallet browser extension | Always capitalize "Freighter" |
+
+## 🧩 Empty-State Copy Templates
+
+Empty states should follow this pattern:
+
+```
+Title: [Noun] + [missing-state verb]
+Description: [What to do next] + [optional benefit]
+```
+
+Examples:
+- "No employees yet → Add employees to get started with payroll."
+- "No transactions yet → Process your first payroll to see it here."
+- "No view keys generated → Generate a view key to grant auditor access."
+
+## 📝 General Guidelines
+
+1. **Accessibility**: Use `aria-live="polite"` on dynamic status messages.
+2. **Brevity**: Keep tooltips under 15 words.
+3. **Consistency**: Reuse the strings above rather than writing new ones.
+4. **Localization-ready**: Avoid idioms that don't translate well.
+5. **Button labels**: Use verbs ("Connect Wallet", "Set up now", "Retry").
+6. **Links vs Buttons**: Use links for navigation (`<a>`), buttons for actions (`<button>`).

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1,0 +1,197 @@
+# Dashboard Setup Guide
+
+A step-by-step guide for running the ZK Payroll Dashboard locally with a realistic Stellar testnet setup.
+
+## 📋 Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Node.js | 18+ | JavaScript runtime |
+| npm / pnpm | Latest | Package manager |
+| Freighter Wallet | Chrome / Firefox extension | Stellar wallet for testnet |
+| Git | Latest | Version control |
+
+## 🚀 Quick Start
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/zkpayroll/zk-payroll-dashboard.git
+cd zk-payroll-dashboard
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env.local
+```
+
+The default values point to Stellar Testnet:
+
+```env
+# ── Stellar Network ──────────────────────────────────────────
+NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# ── Session & Admin ──────────────────────────────────────────
+SESSION_SECRET=your-secret-key-at-least-32-characters-long
+ADMIN_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+> ⚠️ Replace `SESSION_SECRET` with a strong random string (at least 32 characters).
+> Replace `ADMIN_PUBLIC_KEY` with your own Stellar testnet public key (see Wallet Setup below).
+
+### 3. Start the dev server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+## 🔐 Wallet Setup (Freighter)
+
+### Install Freighter
+
+1. Visit the [Freighter Wallet](https://freighter.app/) page.
+2. Install the browser extension for Chrome or Firefox.
+3. Create a new wallet or import an existing Stellar secret key.
+
+### Switch to Testnet
+
+1. Open Freighter (click the extension icon).
+2. Go to **Settings → Network**.
+3. Select **Testnet**.
+4. Confirm the network indicator shows "Testnet".
+
+## 🪙 Fund Your Testnet Account
+
+### Option A: Friendbot (Recommended)
+
+Use Stellar's Friendbot to fund a new testnet account:
+
+```bash
+curl "https://friendbot.stellar.org?addr=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+```
+
+Replace the address with your Freighter wallet's public key.
+
+**Expected response:**
+```json
+{
+  "hash": "...",
+  "result_codes": { "transaction": "tx_success" },
+  ...
+}
+```
+
+### Option B: Stellar Lab
+
+1. Go to [Stellar Lab](https://lab.stellar.org/).
+2. Switch the network to **Testnet**.
+3. Navigate to the **Friendbot** tab.
+4. Paste your public key and click **Get Testnet Lumens**.
+
+### Verify the Balance
+
+1. Open Freighter.
+2. Your balance should now show ~10,000 testnet XLM.
+
+## 🔄 Configure Your Admin Key
+
+After your wallet is funded:
+
+1. Copy your **public key** from Freighter (click on your account → Copy Address).
+2. Open `.env.local`.
+3. Set `ADMIN_PUBLIC_KEY` to your public key.
+
+```
+ADMIN_PUBLIC_KEY=GBXT...YOUR_PUBLIC_KEY_HERE...J29M
+```
+
+## 🧪 Run the Smoke Tests
+
+The project includes smoke tests that verify the critical user journeys:
+
+```bash
+npm run test:smoke
+```
+
+These cover:
+- Wallet connection states (connect, disconnect, loading, error)
+- Payroll initiation (summary cards, proof generation)
+- Dashboard status (history table, status visibility)
+
+## ✅ Validation Checklist
+
+Use this checklist to confirm the dashboard is wired correctly:
+
+### Wallet Connection
+- [ ] Freighter shows **Testnet** network
+- [ ] Freighter is unlocked and funded
+- [ ] Clicking **Connect Wallet** on the dashboard triggers Freighter
+- [ ] The wallet address (truncated) is displayed in the header
+- [ ] The dropdown shows "View on Stellar Expert" and "Copy Address"
+- [ ] Disconnecting clears the wallet state
+
+### Dashboard Home
+- [ ] After connecting, the company setup banner appears (if no company)
+- [ ] Clicking **Set up now** navigates to `/setup`
+- [ ] Dashboard displays payroll summary cards (Total Payroll, Active Employees, Pending Approvals)
+- [ ] Mock ZK proof generation works and shows a commitment hash
+
+### Employee Directory
+- [ ] `/employees` shows the employee directory with filter buttons
+- [ ] All / Active / Inactive / Pending filters work
+- [ ] Empty state is shown when no employees match a filter
+
+### Transaction History
+- [ ] `/history` shows transaction history table
+- [ ] Filters panel can be opened/closed
+- [ ] Status, employee, date range, and payroll run filters work
+- [ ] CSV export downloads a file with filtered results
+- [ ] "No transactions match the current filters" appears when no results
+
+### Compliance / Audit
+- [ ] `/compliance` shows Auditor Access Management
+- [ ] Generating a new view key creates an active key entry
+- [ ] Revealing a key shows the full key ID
+- [ ] Revoking a key marks it as inactive
+- [ ] Expired keys are visually distinguishable
+
+### Navigation
+- [ ] Sidebar links navigate correctly: Dashboard, Employees, History, Compliance
+- [ ] The active page is highlighted in the sidebar
+
+## 🐛 Troubleshooting
+
+### "Freighter not detected"
+- Ensure Freighter is installed and unlocked
+- Refresh the page after installing
+- Check that Freighter is not in "Public" or "Futurenet" mode
+
+### "Failed to connect wallet"
+- Make sure your testnet account is funded
+- Try unlocking and re-locking Freighter
+- Check the browser console for detailed errors
+
+### "Horizon request failed"
+- Verify `.env.local` has the correct URLs
+- Testnet Horizon should be `https://horizon-testnet.stellar.org`
+- Check your internet connection
+
+### "Port 3000 already in use"
+```bash
+# Kill the process on port 3000
+lsof -ti:3000 | xargs kill -9
+# Or use a different port
+npm run dev -- -p 3001
+```
+
+## 📚 Additional Resources
+
+- [Stellar Testnet Guide](https://developers.stellar.org/docs/network/testnet)
+- [Freighter Wallet Docs](https://docs.freighter.app/)
+- [Stellar Expert Explorer](https://testnet.stellarexpert.com/)

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+/**
+ * A hook for reading and writing values to localStorage with JSON serialization.
+ * Falls back to the default value when parsing fails or storage is unavailable.
+ */
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((prev) => {
+        const nextValue =
+          value instanceof Function ? value(prev) : value;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(nextValue));
+        } catch {
+          // Storage full or unavailable — silently fail
+        }
+        return nextValue;
+      });
+    },
+    [key],
+  );
+
+  const removeValue = useCallback(() => {
+    try {
+      window.localStorage.removeItem(key);
+      setStoredValue(initialValue);
+    } catch {
+      // Silently fail
+    }
+  }, [key, initialValue]);
+
+  return [storedValue, setValue, removeValue] as const;
+}


### PR DESCRIPTION
__Description:__ This PR addresses 4 workstreams for the ZK Payroll Dashboard: contributor onboarding docs, standardised UX copy, a reusable empty-state system, and saved filter presets.

### What changed

- __docs/SETUP_GUIDE.md__ — Local development setup, Freighter Testnet wallet setup, Friendbot/Soroban funding, smoke-test instructions, and a checklist-style validation guide for wallet, dashboard, employees, history, compliance, and navigation.
- __docs/CONTENT_STYLE_GUIDE.md__ — Tone/voice standards, exact status label vocabulary, error/success/warning message catalog, core terminology table, and empty-state copy templates.
- __components/ui/EmptyState.tsx__ — Replaced ad-hoc EmptyState props with a typed `EMPTY_STATE_COPY` screen catalog. Added 11 screen presets while keeping the old props working. `EmployeeDirectory` now uses the new screen-based API.
- __hooks/useLocalStorage.ts__ — New generic client hook for localStorage-persisted state (typed, JSON-serialized, with `setValue` and `removeValue`).
- __TransactionHistory__ — Added a Saved Views dropdown (save / apply / rename / delete filter presets, persisted in localStorage), an active-filter bar, and contextual empty-state copy in the table.
closes #61
closes #84
closes #86
closes #82