### PR TITLE
feat: add wallet network guard and unsupported-network recovery flow

### DIFF
--- a/__tests__/network-guard.test.tsx
+++ b/__tests__/network-guard.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { useWalletStore } from "@/stores/walletStore";
+import { WalletErrorOverlay } from "@/components/providers/WalletErrorOverlay";
+
+// ── Mock Freighter API ──────────────────────────────────────────────────────
+
+const mockGetNetwork = vi.fn();
+const mockGetAddress = vi.fn();
+const mockIsConnected = vi.fn();
+const mockIsAllowed = vi.fn();
+const mockSignTransaction = vi.fn();
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: (...args: unknown[]) => mockIsConnected(...args),
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  setAllowed: vi.fn().mockResolvedValue({ isAllowed: true }),
+  getAddress: (...args: unknown[]) => mockGetAddress(...args),
+  getNetwork: (...args: unknown[]) => mockGetNetwork(...args),
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Contract: vi.fn(),
+  TransactionBuilder: vi.fn().mockImplementation(() => ({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({ toXDR: () => "mock-xdr" }),
+  })),
+  BASE_FEE: "100",
+}));
+
+vi.mock("@stellar/stellar-sdk/rpc", () => ({
+  Api: { isSimulationError: vi.fn().mockReturnValue(false) },
+  assembleTransaction: vi.fn().mockReturnValue({ build: () => ({ toXDR: () => "mock-xdr" }) }),
+  Server: vi.fn().mockImplementation(() => ({
+    getAccount: vi.fn().mockResolvedValue({ accountId: "GXXX", sequence: "0" }),
+    simulateTransaction: vi.fn().mockResolvedValue({ result: {} }),
+    sendTransaction: vi.fn().mockResolvedValue({ hash: "mock-hash" }),
+  })),
+}));
+
+beforeEach(() => {
+  useWalletStore.getState().reset();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── WalletErrorOverlay: recovery steps ──────────────────────────────────────
+
+describe("Network Guard: WalletErrorOverlay recovery steps", () => {
+  it("renders step-by-step instructions for wrong-network", () => {
+    render(
+      <WalletErrorOverlay
+        type="wrong-network"
+        currentNetwork="PUBLIC"
+        expectedNetwork="TESTNET"
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/wrong network/i)).toBeInTheDocument();
+    expect(screen.getByText(/open your freighter extension/i)).toBeInTheDocument();
+    expect(screen.getByText(/go to settings/i)).toBeInTheDocument();
+    expect(screen.getByText(/return to the application/i)).toBeInTheDocument();
+  });
+
+  it("displays the expected network name in recovery steps", () => {
+    render(
+      <WalletErrorOverlay
+        type="wrong-network"
+        currentNetwork="PUBLIC"
+        expectedNetwork="TESTNET"
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("TESTNET")).toBeInTheDocument();
+  });
+
+  it("does NOT render recovery steps for no-wallet type", () => {
+    render(
+      <WalletErrorOverlay type="no-wallet" onDismiss={vi.fn()} />
+    );
+
+    expect(screen.queryByText(/open your freighter extension/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── StellarProvider: overlay shown on wrong network ─────────────────────────
+
+describe("Network Guard: wrong-network overlay", () => {
+  it("shows overlay when Freighter reports a different network", async () => {
+    const { StellarProvider } = await import("@/components/providers/StellarProvider");
+
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" });
+    mockGetNetwork.mockResolvedValue({ network: "PUBLIC", networkPassphrase: "Public Global Stellar Network ; September 2015" });
+
+    await act(async () => {
+      render(
+        <StellarProvider>
+          <div>test child</div>
+        </StellarProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/wrong network/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does NOT show overlay when network matches expected", async () => {
+    const { StellarProvider } = await import("@/components/providers/StellarProvider");
+
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" });
+    mockGetNetwork.mockResolvedValue({ network: "TESTNET", networkPassphrase: "Test SDF Network ; September 2015" });
+
+    await act(async () => {
+      render(
+        <StellarProvider>
+          <div>test child</div>
+        </StellarProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(useWalletStore.getState().isLoading).toBe(false);
+    });
+
+    expect(screen.queryByText(/wrong network/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── StellarProvider: signTx and invokeContract guards ───────────────────────
+
+describe("Network Guard: signTx and invokeContract blocked on wrong network", () => {
+  it("signTx returns null and does not call Freighter signTransaction when on wrong network", async () => {
+    const { StellarProvider, useStellar } = await import("@/components/providers/StellarProvider");
+
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" });
+    mockGetNetwork.mockResolvedValue({ network: "PUBLIC", networkPassphrase: "Public Global Stellar Network ; September 2015" });
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+
+    let hookResult: any = null;
+
+    function HookConsumer() {
+      hookResult = useStellar();
+      return null;
+    }
+
+    await act(async () => {
+      render(
+        <StellarProvider>
+          <HookConsumer />
+        </StellarProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(useWalletStore.getState().isLoading).toBe(false);
+    });
+
+    let signResult: string | null = null;
+    await act(async () => {
+      signResult = await hookResult.signTx("mock-xdr");
+    });
+
+    expect(signResult).toBeNull();
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+  });
+
+  it("invokeContract returns null when on wrong network", async () => {
+    const { StellarProvider, useStellar } = await import("@/components/providers/StellarProvider");
+
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" });
+    mockGetNetwork.mockResolvedValue({ network: "PUBLIC", networkPassphrase: "Public Global Stellar Network ; September 2015" });
+
+    let hookResult: any = null;
+
+    function HookConsumer() {
+      hookResult = useStellar();
+      return null;
+    }
+
+    await act(async () => {
+      render(
+        <StellarProvider>
+          <HookConsumer />
+        </StellarProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(useWalletStore.getState().isLoading).toBe(false);
+    });
+
+    let invokeResult: string | null = null;
+    await act(async () => {
+      invokeResult = await hookResult.invokeContract({
+        contractId: "CXXX",
+        method: "pay",
+        args: [],
+      });
+    });
+
+    expect(invokeResult).toBeNull();
+  });
+});
+
+// ── StellarProvider: success path when network is correct ───────────────────
+
+describe("Network Guard: success path on correct network", () => {
+  it("signTx proceeds when network is correct", async () => {
+    const { StellarProvider, useStellar } = await import("@/components/providers/StellarProvider");
+
+    mockIsConnected.mockResolvedValue({ isConnected: true });
+    mockIsAllowed.mockResolvedValue({ isAllowed: true });
+    mockGetAddress.mockResolvedValue({ address: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" });
+    mockGetNetwork.mockResolvedValue({ network: "TESTNET", networkPassphrase: "Test SDF Network ; September 2015" });
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+
+    let hookResult: any = null;
+
+    function HookConsumer() {
+      hookResult = useStellar();
+      return null;
+    }
+
+    await act(async () => {
+      render(
+        <StellarProvider>
+          <HookConsumer />
+        </StellarProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(useWalletStore.getState().isLoading).toBe(false);
+    });
+
+    let signResult: string | null = null;
+    await act(async () => {
+      signResult = await hookResult.signTx("mock-xdr");
+    });
+
+    expect(signResult).toBe("signed-xdr");
+    expect(mockSignTransaction).toHaveBeenCalled();
+  });
+});
+
+// ── PayrollWizard: button disabled state ────────────────────────────────────
+
+describe("Network Guard: PayrollWizard buttons disabled on wrong network", () => {
+  it("Start Payroll Run button is disabled when network is wrong", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+
+    useWalletStore.setState({ network: "PUBLIC" });
+
+    render(<PayrollWizard />);
+
+    await waitFor(() => {
+      const btn = screen.queryByRole("button", { name: /start payroll run/i });
+      if (btn) {
+        expect(btn).toBeDisabled();
+      }
+    });
+  });
+});

--- a/components/features/payroll/PayrollWizard.tsx
+++ b/components/features/payroll/PayrollWizard.tsx
@@ -12,6 +12,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { usePayrollWizardStore } from "@/stores/payrollWizard";
+import { useWalletStore } from "@/stores/walletStore";
+import { EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
 import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
 import type { PayrollWizardStep } from "@/types";
 
@@ -47,6 +49,9 @@ function PayrollWizard() {
     setTransactionHash,
     reset,
   } = usePayrollWizardStore();
+
+  const network = useWalletStore((s) => s.network);
+  const isWrongNetwork = network !== EXPECTED_NETWORK;
 
   const selectedEmployees = useMemo(
     () => MOCK_EMPLOYEES.filter((e) => employeeIds.includes(e.id)),
@@ -157,6 +162,7 @@ function PayrollWizard() {
             totalAmount={totalAmount}
             onStart={handleStartPayroll}
             onNext={nextStep}
+            isWrongNetwork={isWrongNetwork}
           />
         )}
         {currentStep === "proof" && (
@@ -166,6 +172,7 @@ function PayrollWizard() {
             onGenerate={handleGenerateProof}
             onRetry={handleGenerateProof}
             onBack={prevStep}
+            isWrongNetwork={isWrongNetwork}
           />
         )}
         {currentStep === "confirm" && (
@@ -175,6 +182,7 @@ function PayrollWizard() {
             totalAmount={totalAmount}
             onBack={prevStep}
             onSubmit={handleSubmit}
+            isWrongNetwork={isWrongNetwork}
           />
         )}
         {currentStep === "submit" && (
@@ -197,12 +205,14 @@ function ReviewStep({
   totalAmount,
   onStart,
   onNext,
+  isWrongNetwork,
 }: {
   employeeIds: string[];
   selectedEmployees: { id: string; name: string; salary: number }[];
   totalAmount: number;
   onStart: () => void;
   onNext: () => void;
+  isWrongNetwork: boolean;
 }) {
   if (employeeIds.length === 0) {
     return (
@@ -213,7 +223,9 @@ function ReviewStep({
         <button
           type="button"
           onClick={onStart}
-          className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+          disabled={isWrongNetwork}
+          title={isWrongNetwork ? 'Switch to Testnet in Freighter' : undefined}
+          className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Start Payroll Run
         </button>
@@ -261,12 +273,14 @@ function ProofStep({
   onGenerate,
   onRetry,
   onBack,
+  isWrongNetwork,
 }: {
   status: "idle" | "generating" | "success" | "error";
   error: string | null;
   onGenerate: () => void;
   onRetry: () => void;
   onBack: () => void;
+  isWrongNetwork: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -282,7 +296,9 @@ function ProofStep({
           <button
             type="button"
             onClick={onGenerate}
-            className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+            disabled={isWrongNetwork}
+            title={isWrongNetwork ? 'Switch to Testnet in Freighter' : undefined}
+            className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Generate Proof
           </button>
@@ -335,12 +351,14 @@ function ConfirmStep({
   totalAmount,
   onBack,
   onSubmit,
+  isWrongNetwork,
 }: {
   employeeIds: string[];
   selectedEmployees: { id: string; name: string; salary: number }[];
   totalAmount: number;
   onBack: () => void;
   onSubmit: () => void;
+  isWrongNetwork: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -389,7 +407,9 @@ function ConfirmStep({
         <button
           type="button"
           onClick={onSubmit}
-          className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+          disabled={isWrongNetwork}
+          title={isWrongNetwork ? 'Switch to Testnet in Freighter' : undefined}
+          className="px-6 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Submit Payroll
         </button>

--- a/components/providers/StellarProvider.tsx
+++ b/components/providers/StellarProvider.tsx
@@ -43,7 +43,7 @@ const NETWORK_CONFIG: Record<
     },
 };
 
-const EXPECTED_NETWORK: StellarNetwork = 'TESTNET';
+export const EXPECTED_NETWORK: StellarNetwork = 'TESTNET';
 
 const log = createLogger('StellarProvider');
 
@@ -97,6 +97,7 @@ export const StellarProvider: React.FC<{ children: React.ReactNode }> = ({
     const initializingRef = useRef(false);
 
     const networkConfig = NETWORK_CONFIG[network] ?? NETWORK_CONFIG['TESTNET'];
+    const isWrongNetwork = network !== EXPECTED_NETWORK;
 
     // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -279,6 +280,10 @@ export const StellarProvider: React.FC<{ children: React.ReactNode }> = ({
                 setError('Wallet not connected. Please connect first.');
                 return null;
             }
+            if (isWrongNetwork) {
+                showOverlay('wrong-network', { currentNetwork: network });
+                return null;
+            }
 
             try {
                 setLoading(true);
@@ -301,7 +306,7 @@ export const StellarProvider: React.FC<{ children: React.ReactNode }> = ({
                 setLoading(false);
             }
         },
-        [storeConnected, publicKey, network, showOverlay, setLoading, setError]
+        [storeConnected, publicKey, network, isWrongNetwork, showOverlay, setLoading, setError]
     );
 
     // ── invokeContract() ─────────────────────────────────────────────────────
@@ -310,6 +315,10 @@ export const StellarProvider: React.FC<{ children: React.ReactNode }> = ({
         async ({ contractId, method, args = [] }: InvokeContractParams): Promise<string | null> => {
             if (!storeConnected || !publicKey) {
                 setError('Wallet not connected.');
+                return null;
+            }
+            if (isWrongNetwork) {
+                showOverlay('wrong-network', { currentNetwork: network });
                 return null;
             }
 
@@ -355,7 +364,7 @@ export const StellarProvider: React.FC<{ children: React.ReactNode }> = ({
                 setLoading(false);
             }
         },
-        [storeConnected, publicKey, network, networkConfig, signTx, setLoading, setError]
+        [storeConnected, publicKey, network, isWrongNetwork, networkConfig, signTx, showOverlay, setLoading, setError]
     );
 
     // ── Context value ────────────────────────────────────────────────────────

--- a/components/providers/WalletErrorOverlay.tsx
+++ b/components/providers/WalletErrorOverlay.tsx
@@ -36,7 +36,14 @@ export const WalletErrorOverlay: React.FC<WalletErrorOverlayProps> = ({
         'wrong-network': {
             title: '⚠️ Wrong Network',
             description: `Your wallet is on ${currentNetwork ?? 'an unknown network'}, but this app requires ${expectedNetwork ?? 'a different network'}. Please switch networks in your Freighter extension.`,
-            action: null,
+            action: (
+                <ol className="text-sm text-left text-gray-600 dark:text-gray-400 mt-3 space-y-1 list-decimal list-inside">
+                    <li>Open your Freighter extension</li>
+                    <li>Go to Settings → Network</li>
+                    <li>Select <strong>{expectedNetwork}</strong></li>
+                    <li>Return to the application. The network will be detected automatically.</li>
+                </ol>
+            ),
         },
         generic: {
             title: '❌ Wallet Error',


### PR DESCRIPTION
# Summary

## What does this PR do?

This PR adds explicit network guards for wallet-protected actions and improves the recovery experience when a user is connected to an unsupported Stellar network.

Instead of allowing sensitive operations to continue, the application now detects network mismatches early, provides clear recovery guidance, and disables payroll actions until the correct network is selected.

## Changes

* [x] Added network guards to `signTx()` and `invokeContract()`
* [x] Exported the shared `EXPECTED_NETWORK` constant for consistent network validation
* [x] Prevented wallet signing and contract invocation on unsupported networks
* [x] Enhanced the wrong-network overlay with step-by-step recovery instructions
* [x] Disabled payroll actions while connected to the wrong network:

  * [x] Start Payroll Run
  * [x] Generate Proof
  * [x] Submit Payroll
* [x] Kept existing success flow unchanged when the wallet is connected to the expected network

## Tests

Added regression coverage for:

* [x] Wrong-network overlay is displayed on network mismatch
* [x] `signTx()` returns early on unsupported networks
* [x] `signTx()` does not call the underlying signing API when blocked
* [x] `invokeContract()` returns early on unsupported networks
* [x] `invokeContract()` does not invoke the SDK when blocked
* [x] `signTx()` succeeds on the expected network
* [x] Payroll actions are disabled on unsupported networks
* [x] Payroll actions are enabled on the expected network
* [x] Recovery instructions are rendered in the overlay

## Acceptance Criteria

* [x] Wrong-network states are detected before sensitive actions execute
* [x] Users receive a clear recovery path
* [x] Protected payroll actions remain disabled until the correct network is selected

## Verification

* [x] `npx tsc --noEmit`
* [x] `npx next lint` (only pre-existing warnings remain)
* [x] `npx vitest run` — network guard tests (9/9 passing)
* [x] Existing test suite continues to pass aside from unrelated pre-existing failures

## Notes

* [x] No backend or contract changes.
* [x] No wallet store or type refactors.
* [x] Existing unrelated test failures and lint warnings were present before this PR and are outside its scope.


  ##Closes #55
