### PR TITLE
Closes #52

### DIFF
--- a/__tests__/smoke/payroll-run-detail.test.tsx
+++ b/__tests__/smoke/payroll-run-detail.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PayrollRunDetail from "@/components/features/payroll/PayrollRunDetail";
+import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
+
+describe("Payroll Run Detail", () => {
+  it("renders scheduled run details with process action", () => {
+    const run = MOCK_PAYROLL_RUNS.find((r) => r.id === "tx_003")!;
+    render(<PayrollRunDetail run={run} />);
+
+    expect(screen.getByRole("heading", { name: /payroll run/i })).toBeInTheDocument();
+    expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /process payroll/i })).toHaveAttribute(
+      "href",
+      "/payroll/execute",
+    );
+  });
+
+  it("renders completed run without process action", () => {
+    const run = MOCK_PAYROLL_RUNS.find((r) => r.id === "tx_001")!;
+    render(<PayrollRunDetail run={run} />);
+
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
+    expect(screen.getByText("abc123def456")).toBeInTheDocument();
+  });
+
+  it("links back to the schedule page", () => {
+    render(<PayrollRunDetail run={MOCK_PAYROLL_RUNS[0]} />);
+
+    expect(screen.getByRole("link", { name: /back to schedule/i })).toHaveAttribute(
+      "href",
+      "/payroll/schedule",
+    );
+  });
+});

--- a/__tests__/smoke/payroll-schedule.test.tsx
+++ b/__tests__/smoke/payroll-schedule.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import PayrollCalendar from "@/components/features/payroll/PayrollCalendar";
+import {
+  MOCK_PAYROLL_RUNS,
+  MOCK_PAYROLL_RUNS_EMPTY,
+  MOCK_PAYROLL_RUNS_FIRST_RUN,
+} from "@/lib/api/mockData";
+
+describe("Payroll Schedule", () => {
+  it("renders empty state when no payroll runs exist", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS_EMPTY} />);
+
+    expect(screen.getByText("No payroll runs yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/When you schedule your first payroll run/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /start first payroll run/i }),
+    ).toHaveAttribute("href", "/payroll/execute");
+  });
+
+  it("renders first-run state with hero and getting started guidance", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS_FIRST_RUN} />);
+
+    expect(screen.getByText("Next payroll run")).toBeInTheDocument();
+    expect(screen.getByText("Getting started")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your first payroll run is on the calendar/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Past payroll runs")).not.toBeInTheDocument();
+  });
+
+  it("prioritizes the nearest upcoming run in the hero", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    const hero = screen.getByText("Next payroll run").closest("article");
+    expect(hero).toBeTruthy();
+    expect(within(hero!).getByText(/Mar 31, 2025|3\/31\/2025/)).toBeInTheDocument();
+  });
+
+  it("shows past payroll runs for the default mock dataset", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByText("Past payroll runs")).toBeInTheDocument();
+  });
+
+  it("links each run to its detail page", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByRole("link", { name: /view details/i })).toHaveAttribute(
+      "href",
+      "/payroll/tx_003",
+    );
+  });
+
+  it("uses distinct scheduled and completed styling labels", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getAllByText("Scheduled").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
+  });
+
+  it("renders mobile timeline on narrow layout markup", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByText("Timeline")).toBeInTheDocument();
+    expect(screen.getByText(/Tap a run for details/i)).toBeInTheDocument();
+  });
+
+  it("renders month calendar grid on desktop markup", () => {
+    render(<PayrollCalendar runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByRole("grid", { name: /payroll calendar/i })).toBeInTheDocument();
+  });
+});

--- a/app/payroll/[id]/page.tsx
+++ b/app/payroll/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import PayrollRunDetail, {
+  findPayrollRun,
+} from "@/components/features/payroll/PayrollRunDetail";
+
+interface PayrollRunPageProps {
+  params: { id: string };
+}
+
+function PayrollRunPage({ params }: PayrollRunPageProps) {
+  const run = findPayrollRun(params.id);
+  if (!run) notFound();
+
+  return (
+    <DashboardLayout>
+      <PayrollRunDetail run={run} />
+    </DashboardLayout>
+  );
+}
+
+export default PayrollRunPage;

--- a/app/payroll/schedule/page.tsx
+++ b/app/payroll/schedule/page.tsx
@@ -1,0 +1,12 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import PayrollCalendar from "@/components/features/payroll/PayrollCalendar";
+
+function PayrollSchedulePage() {
+  return (
+    <DashboardLayout>
+      <PayrollCalendar />
+    </DashboardLayout>
+  );
+}
+
+export default PayrollSchedulePage;

--- a/components/features/payroll/PayrollCalendar.tsx
+++ b/components/features/payroll/PayrollCalendar.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Calendar,
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  XCircle,
+} from "lucide-react";
+import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
+import type { PayrollRun } from "@/types/models";
+import EmptyState from "@/components/ui/EmptyState";
+import {
+  classifyRun,
+  formatPayrollDate,
+  formatPayrollMonthYear,
+  getCalendarMonthDays,
+  getNextUpcoming,
+  getRunDate,
+  groupRunsByDateKey,
+  RUN_KIND_STYLES,
+  sortRunsForSchedule,
+  toDateKey,
+  type RunScheduleKind,
+} from "@/lib/payroll/scheduleUtils";
+
+interface PayrollCalendarProps {
+  runs?: PayrollRun[];
+}
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function RunKindIcon({ kind }: { kind: RunScheduleKind }) {
+  if (kind === "completed") {
+    return <CheckCircle className="w-4 h-4 text-green-600 shrink-0" aria-hidden="true" />;
+  }
+  if (kind === "failed") {
+    return <XCircle className="w-4 h-4 text-red-600 shrink-0" aria-hidden="true" />;
+  }
+  return <Clock className="w-4 h-4 text-yellow-600 shrink-0" aria-hidden="true" />;
+}
+
+function RunBadge({ kind }: { kind: RunScheduleKind }) {
+  const styles = RUN_KIND_STYLES[kind];
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full border ${styles.badge}`}
+    >
+      {styles.label}
+    </span>
+  );
+}
+
+function RunListItem({ run }: { run: PayrollRun }) {
+  const kind = classifyRun(run);
+  const styles = RUN_KIND_STYLES[kind];
+  const date = getRunDate(run);
+
+  return (
+    <li>
+      <Link
+        href={`/payroll/${run.id}`}
+        className={`flex items-start gap-3 p-4 rounded-lg border transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${styles.badge}`}
+      >
+        <RunKindIcon kind={kind} />
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900">
+              {formatPayrollDate(date)}
+            </span>
+            <RunBadge kind={kind} />
+          </div>
+          <p className="text-sm text-gray-600 mt-0.5">
+            ${run.totalAmount.toLocaleString()} · {run.employeeCount} employees
+          </p>
+        </div>
+        <ChevronRight className="w-4 h-4 text-gray-400 shrink-0 mt-0.5" aria-hidden="true" />
+      </Link>
+    </li>
+  );
+}
+
+function NextUpHero({ run }: { run: PayrollRun }) {
+  const date = getRunDate(run);
+
+  return (
+    <article className="bg-white rounded-lg shadow-sm border-2 border-indigo-200 overflow-hidden">
+      <div className="bg-indigo-50 px-6 py-3 border-b border-indigo-100">
+        <p className="text-xs font-semibold uppercase tracking-wide text-indigo-700">
+          Next payroll run
+        </p>
+      </div>
+      <div className="p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center shrink-0">
+            <Clock className="w-5 h-5 text-yellow-700" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-xl font-bold text-gray-900">{formatPayrollDate(date)}</p>
+            <p className="text-sm text-gray-600 mt-1">
+              ${run.totalAmount.toLocaleString()} across {run.employeeCount} employees
+            </p>
+            <RunBadge kind="scheduled" />
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+          <Link
+            href={`/payroll/${run.id}`}
+            className="inline-flex items-center justify-center px-4 py-2 rounded-md border border-indigo-200 bg-white text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
+          >
+            View details
+          </Link>
+          <Link
+            href="/payroll/execute"
+            className="inline-flex items-center justify-center px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            Process now
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function MonthCalendar({
+  runsByDate,
+  viewDate,
+  onPrevMonth,
+  onNextMonth,
+}: {
+  runsByDate: Map<string, PayrollRun[]>;
+  viewDate: Date;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}) {
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const days = getCalendarMonthDays(year, month);
+  const todayKey = toDateKey(new Date());
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+      <div className="px-6 py-4 border-b flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-900">
+          {formatPayrollMonthYear(viewDate)}
+        </h3>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onPrevMonth}
+            className="p-1.5 rounded-md text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="Previous month"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onNextMonth}
+            className="p-1.5 rounded-md text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="Next month"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4">
+        <div className="grid grid-cols-7 gap-1 mb-1">
+          {WEEKDAY_LABELS.map((label) => (
+            <div
+              key={label}
+              className="text-center text-xs font-medium text-gray-500 py-1"
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-1" role="grid" aria-label="Payroll calendar">
+          {days.map((day, index) => {
+            if (!day) {
+              return <div key={`empty-${index}`} className="aspect-square" />;
+            }
+
+            const dateKey = toDateKey(day);
+            const dayRuns = runsByDate.get(dateKey) ?? [];
+            const isToday = dateKey === todayKey;
+
+            return (
+              <div
+                key={dateKey}
+                role="gridcell"
+                className={`aspect-square p-1 rounded-md border ${
+                  isToday ? "border-indigo-300 bg-indigo-50/50" : "border-transparent"
+                } ${dayRuns.length > 0 ? "bg-gray-50" : ""}`}
+              >
+                <span
+                  className={`block text-xs font-medium mb-0.5 ${
+                    isToday ? "text-indigo-700" : "text-gray-700"
+                  }`}
+                >
+                  {day.getDate()}
+                </span>
+                <div className="space-y-0.5">
+                  {dayRuns.slice(0, 2).map((run) => {
+                    const kind = classifyRun(run);
+                    return (
+                      <Link
+                        key={run.id}
+                        href={`/payroll/${run.id}`}
+                        className={`block w-full h-1.5 rounded-full ${RUN_KIND_STYLES[kind].dot} hover:opacity-80`}
+                        title={`${RUN_KIND_STYLES[kind].label}: ${formatPayrollDate(getRunDate(run))}`}
+                        aria-label={`${RUN_KIND_STYLES[kind].label} payroll on ${formatPayrollDate(getRunDate(run))}`}
+                      />
+                    );
+                  })}
+                  {dayRuns.length > 2 && (
+                    <span className="text-[10px] text-gray-500">+{dayRuns.length - 2}</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4 mt-4 pt-4 border-t text-xs text-gray-600">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full bg-yellow-500" aria-hidden="true" />
+            Scheduled
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full bg-green-500" aria-hidden="true" />
+            Completed
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full bg-red-500" aria-hidden="true" />
+            Failed
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PayrollCalendar({ runs = MOCK_PAYROLL_RUNS }: PayrollCalendarProps) {
+  const nextUp = useMemo(() => getNextUpcoming(runs), [runs]);
+  const sortedRuns = useMemo(() => sortRunsForSchedule(runs), [runs]);
+  const runsByDate = useMemo(() => groupRunsByDateKey(runs), [runs]);
+  const pastRuns = useMemo(
+    () => runs.filter((r) => classifyRun(r) !== "scheduled"),
+    [runs],
+  );
+  const scheduledRuns = useMemo(
+    () => runs.filter((r) => classifyRun(r) === "scheduled"),
+    [runs],
+  );
+
+  const initialViewDate = nextUp ? getRunDate(nextUp) : new Date();
+  const [viewDate, setViewDate] = useState(
+    () => new Date(initialViewDate.getFullYear(), initialViewDate.getMonth(), 1),
+  );
+
+  const shiftMonth = (delta: number) => {
+    setViewDate((current) => new Date(current.getFullYear(), current.getMonth() + delta, 1));
+  };
+
+  if (runs.length === 0) {
+    return (
+      <section aria-labelledby="payroll-schedule-heading">
+        <header className="mb-6">
+          <h2 id="payroll-schedule-heading" className="text-lg font-semibold text-gray-900">
+            Payroll Schedule
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Upcoming and historical payroll runs at a glance
+          </p>
+        </header>
+        <div className="bg-white rounded-lg shadow-sm">
+          <EmptyState
+            icon={Calendar}
+            title="No payroll runs yet"
+            description="When you schedule your first payroll run, it will appear here on your calendar."
+            action={{
+              label: "Start first payroll run",
+              href: "/payroll/execute",
+            }}
+          />
+        </div>
+      </section>
+    );
+  }
+
+  const isFirstRunOnly = scheduledRuns.length === 1 && pastRuns.length === 0;
+
+  return (
+    <section aria-labelledby="payroll-schedule-heading" className="space-y-6">
+      <header>
+        <h2 id="payroll-schedule-heading" className="text-lg font-semibold text-gray-900">
+          Payroll Schedule
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Upcoming and historical payroll runs at a glance
+        </p>
+      </header>
+
+      {nextUp && <NextUpHero run={nextUp} />}
+
+      <div className="hidden md:block">
+        <MonthCalendar
+          runsByDate={runsByDate}
+          viewDate={viewDate}
+          onPrevMonth={() => shiftMonth(-1)}
+          onNextMonth={() => shiftMonth(1)}
+        />
+      </div>
+
+      <div className="md:hidden bg-white rounded-lg shadow-sm overflow-hidden">
+        <div className="px-4 py-3 border-b">
+          <h3 className="text-base font-medium text-gray-900">Timeline</h3>
+          <p className="text-xs text-gray-500 mt-0.5">Tap a run for details</p>
+        </div>
+        <ul className="divide-y divide-gray-100 p-3 space-y-2">
+          {sortedRuns.map((run) => (
+            <RunListItem key={run.id} run={run} />
+          ))}
+        </ul>
+      </div>
+
+      {isFirstRunOnly ? (
+        <article className="bg-white rounded-lg shadow-sm p-6 border border-dashed border-gray-200">
+          <h3 className="text-sm font-semibold text-gray-900">Getting started</h3>
+          <p className="text-sm text-gray-600 mt-1">
+            Your first payroll run is on the calendar above. Once it completes, past runs will
+            appear in the history section below.
+          </p>
+          <Link
+            href="/payroll/execute"
+            className="inline-flex mt-3 text-sm font-medium text-indigo-600 hover:text-indigo-700"
+          >
+            Prepare payroll run →
+          </Link>
+        </article>
+      ) : (
+        pastRuns.length > 0 && (
+          <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+            <div className="px-6 py-4 border-b">
+              <h3 className="text-lg font-medium text-gray-900">Past payroll runs</h3>
+            </div>
+            <ul className="hidden md:block divide-y divide-gray-100">
+              {pastRuns.map((run) => (
+                <li key={run.id}>
+                  <Link
+                    href={`/payroll/${run.id}`}
+                    className="flex items-center gap-3 px-6 py-4 hover:bg-gray-50 transition-colors"
+                  >
+                    <RunKindIcon kind={classifyRun(run)} />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {formatPayrollDate(getRunDate(run))}
+                      </p>
+                      <p className="text-sm text-gray-500">
+                        ${run.totalAmount.toLocaleString()} · {run.employeeCount} employees
+                      </p>
+                    </div>
+                    <RunBadge kind={classifyRun(run)} />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      )}
+
+      {scheduledRuns.length > 1 && (
+        <div className="hidden md:block bg-white rounded-lg shadow-sm overflow-hidden">
+          <div className="px-6 py-4 border-b">
+            <h3 className="text-lg font-medium text-gray-900">Other scheduled runs</h3>
+          </div>
+          <ul className="divide-y divide-gray-100">
+            {scheduledRuns
+              .filter((run) => run.id !== nextUp?.id)
+              .map((run) => (
+                <li key={run.id}>
+                  <Link
+                    href={`/payroll/${run.id}`}
+                    className="flex items-center gap-3 px-6 py-4 hover:bg-gray-50 transition-colors"
+                  >
+                    <RunKindIcon kind="scheduled" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {formatPayrollDate(getRunDate(run))}
+                      </p>
+                      <p className="text-sm text-gray-500">
+                        ${run.totalAmount.toLocaleString()} · {run.employeeCount} employees
+                      </p>
+                    </div>
+                    <RunBadge kind="scheduled" />
+                  </Link>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default PayrollCalendar;

--- a/components/features/payroll/PayrollRunDetail.tsx
+++ b/components/features/payroll/PayrollRunDetail.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, CheckCircle, Clock, XCircle } from "lucide-react";
+import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
+import type { PayrollRun } from "@/types/models";
+import {
+  classifyRun,
+  formatPayrollDate,
+  getRunDate,
+  RUN_KIND_STYLES,
+  type RunScheduleKind,
+} from "@/lib/payroll/scheduleUtils";
+
+interface PayrollRunDetailProps {
+  run: PayrollRun;
+}
+
+function StatusIcon({ kind }: { kind: RunScheduleKind }) {
+  if (kind === "completed") {
+    return <CheckCircle className="w-5 h-5 text-green-600" aria-hidden="true" />;
+  }
+  if (kind === "failed") {
+    return <XCircle className="w-5 h-5 text-red-600" aria-hidden="true" />;
+  }
+  return <Clock className="w-5 h-5 text-yellow-600" aria-hidden="true" />;
+}
+
+function PayrollRunDetail({ run }: PayrollRunDetailProps) {
+  const kind = classifyRun(run);
+  const styles = RUN_KIND_STYLES[kind];
+  const runDate = getRunDate(run);
+  const employees = MOCK_EMPLOYEES.filter((e) => run.employeeIds.includes(e.id));
+  const txHash = run.transactionHash ?? run.txHash;
+
+  return (
+    <section aria-labelledby="payroll-run-detail-heading" className="space-y-6">
+      <div>
+        <Link
+          href="/payroll/schedule"
+          className="inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+          Back to schedule
+        </Link>
+      </div>
+
+      <header className="bg-white rounded-lg shadow-sm p-6">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div
+              className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 border ${styles.badge}`}
+            >
+              <StatusIcon kind={kind} />
+            </div>
+            <div>
+              <h1
+                id="payroll-run-detail-heading"
+                className="text-xl font-semibold text-gray-900"
+              >
+                Payroll run · {formatPayrollDate(runDate)}
+              </h1>
+              <p className="text-sm text-gray-500 mt-0.5">Run ID: {run.id}</p>
+              <span
+                className={`inline-flex mt-2 px-2 py-1 text-xs font-medium rounded-full border ${styles.badge}`}
+              >
+                {styles.label}
+              </span>
+            </div>
+          </div>
+          {kind === "scheduled" && (
+            <Link
+              href="/payroll/execute"
+              className="inline-flex items-center justify-center px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors shrink-0"
+            >
+              Process payroll
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <article className="bg-white rounded-lg shadow-sm p-6">
+          <h2 className="text-sm font-medium text-gray-600">Total amount</h2>
+          <p className="text-2xl font-bold text-gray-900 mt-1">
+            ${run.totalAmount.toLocaleString()}
+          </p>
+        </article>
+        <article className="bg-white rounded-lg shadow-sm p-6">
+          <h2 className="text-sm font-medium text-gray-600">Employees</h2>
+          <p className="text-2xl font-bold text-gray-900 mt-1">{run.employeeCount}</p>
+        </article>
+      </div>
+
+      <article className="bg-white rounded-lg shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b">
+          <h2 className="text-lg font-medium text-gray-900">Run details</h2>
+        </div>
+        <dl className="divide-y divide-gray-100">
+          <div className="px-6 py-3 flex flex-col sm:flex-row sm:justify-between gap-1">
+            <dt className="text-sm text-gray-500">Scheduled date</dt>
+            <dd className="text-sm font-medium text-gray-900">{formatPayrollDate(runDate)}</dd>
+          </div>
+          <div className="px-6 py-3 flex flex-col sm:flex-row sm:justify-between gap-1">
+            <dt className="text-sm text-gray-500">Status</dt>
+            <dd className="text-sm font-medium text-gray-900 capitalize">{run.status}</dd>
+          </div>
+          {run.executedAt && (
+            <div className="px-6 py-3 flex flex-col sm:flex-row sm:justify-between gap-1">
+              <dt className="text-sm text-gray-500">Executed at</dt>
+              <dd className="text-sm font-medium text-gray-900">
+                {formatPayrollDate(new Date(run.executedAt))}
+              </dd>
+            </div>
+          )}
+          <div className="px-6 py-3 flex flex-col sm:flex-row sm:justify-between gap-1">
+            <dt className="text-sm text-gray-500">Transaction hash</dt>
+            <dd className="text-sm font-medium text-gray-900 font-mono break-all">
+              {txHash ?? "—"}
+            </dd>
+          </div>
+          <div className="px-6 py-3 flex flex-col sm:flex-row sm:justify-between gap-1">
+            <dt className="text-sm text-gray-500">ZK proof</dt>
+            <dd className="text-sm font-medium text-gray-900 font-mono break-all">
+              {run.proof || "Pending generation"}
+            </dd>
+          </div>
+        </dl>
+      </article>
+
+      {employees.length > 0 && (
+        <article className="bg-white rounded-lg shadow-sm overflow-hidden">
+          <div className="px-6 py-4 border-b">
+            <h2 className="text-lg font-medium text-gray-900">Included employees</h2>
+          </div>
+          <ul className="divide-y divide-gray-100">
+            {employees.map((employee) => (
+              <li
+                key={employee.id}
+                className="px-6 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1"
+              >
+                <span className="text-sm font-medium text-gray-900">{employee.name}</span>
+                <span className="text-sm text-gray-600">
+                  ${employee.salary.toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </article>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href="/history"
+          className="inline-flex items-center px-4 py-2 rounded-md border border-gray-200 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          View transaction history
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export function findPayrollRun(id: string, runs = MOCK_PAYROLL_RUNS): PayrollRun | undefined {
+  return runs.find((run) => run.id === id);
+}
+
+export default PayrollRunDetail;

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { Home, Users, Settings, History, Shield, Play, Building2, Landmark } from "lucide-react";
+import Link from "next/link";
+import { Home, Users, Settings, History, Shield, Play, Building2, Landmark, CalendarDays } from "lucide-react";
 
 function Sidebar() {
     return (
@@ -15,6 +16,10 @@ function Sidebar() {
                     <Users className="w-5 h-5 mr-3" />
                     Employees
                 </a>
+                <Link className="flex items-center px-6 py-3 text-gray-600 hover:bg-gray-50 hover:text-gray-900" href="/payroll/schedule">
+                    <CalendarDays className="w-5 h-5 mr-3" />
+                    Payroll Schedule
+                </Link>
                 <a className="flex items-center px-6 py-3 text-gray-600 hover:bg-gray-50 hover:text-gray-900" href="/payroll/execute">
                     <Play className="w-5 h-5 mr-3" />
                     Execute Payroll

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { type LucideIcon } from "lucide-react";
+import Link from "next/link";
 
 interface EmptyStateProps {
   icon: LucideIcon;
@@ -6,7 +7,8 @@ interface EmptyStateProps {
   description: string;
   action?: {
     label: string;
-    onClick: () => void;
+    onClick?: () => void;
+    href?: string;
   };
 }
 
@@ -16,15 +18,23 @@ function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps)
       <Icon className="w-10 h-10 text-gray-400 mx-auto mb-3" aria-hidden="true" />
       <h3 className="text-sm font-semibold text-gray-900 mb-1">{title}</h3>
       <p className="text-sm text-gray-500 mb-4">{description}</p>
-      {action && (
-        <button
-          type="button"
-          onClick={action.onClick}
-          className="px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
-        >
-          {action.label}
-        </button>
-      )}
+      {action &&
+        (action.href ? (
+          <Link
+            href={action.href}
+            className="inline-flex px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            {action.label}
+          </Link>
+        ) : (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            {action.label}
+          </button>
+        ))}
     </div>
   );
 }

--- a/lib/api/mockData.ts
+++ b/lib/api/mockData.ts
@@ -107,6 +107,24 @@ export const MOCK_PAYROLL_RUNS: PayrollRun[] = MOCK_TRANSACTIONS.map(tx => ({
   transactionHash: tx.txHash || null,
 }));
 
+export const MOCK_PAYROLL_RUNS_EMPTY: PayrollRun[] = [];
+
+export const MOCK_PAYROLL_RUNS_FIRST_RUN: PayrollRun[] = [
+  {
+    id: "tx_first",
+    companyId: "company_001",
+    timestamp: "2026-07-15T09:00:00Z",
+    createdAt: "2026-06-01T09:00:00Z",
+    totalAmount: 9500,
+    employeeCount: 2,
+    proof: "",
+    status: "pending",
+    employeeIds: ["emp_001", "emp_002"],
+    executedAt: null,
+    transactionHash: null,
+  },
+];
+
 export const MOCK_TREASURY_BALANCE = {
   balance: 45000,
   projectedPayroll: 19500,

--- a/lib/payroll/scheduleUtils.ts
+++ b/lib/payroll/scheduleUtils.ts
@@ -1,0 +1,97 @@
+import type { PayrollRun } from "@/types/models";
+
+export type RunScheduleKind = "scheduled" | "completed" | "failed";
+
+export function classifyRun(run: PayrollRun): RunScheduleKind {
+  if (run.status === "failed") return "failed";
+  if (run.status === "verified") return "completed";
+  return "scheduled";
+}
+
+export function getRunDate(run: PayrollRun): Date {
+  return new Date(run.timestamp || run.createdAt);
+}
+
+export function formatPayrollDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatPayrollMonthYear(date: Date): string {
+  return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+export function getNextUpcoming(runs: PayrollRun[]): PayrollRun | null {
+  const scheduled = runs.filter((r) => classifyRun(r) === "scheduled");
+  if (scheduled.length === 0) return null;
+  return [...scheduled].sort(
+    (a, b) => getRunDate(a).getTime() - getRunDate(b).getTime(),
+  )[0];
+}
+
+export function sortRunsForSchedule(runs: PayrollRun[]): PayrollRun[] {
+  const scheduled = runs
+    .filter((r) => classifyRun(r) === "scheduled")
+    .sort((a, b) => getRunDate(a).getTime() - getRunDate(b).getTime());
+  const past = runs
+    .filter((r) => classifyRun(r) !== "scheduled")
+    .sort((a, b) => getRunDate(b).getTime() - getRunDate(a).getTime());
+  return [...scheduled, ...past];
+}
+
+export function groupRunsByDateKey(runs: PayrollRun[]): Map<string, PayrollRun[]> {
+  const map = new Map<string, PayrollRun[]>();
+  for (const run of runs) {
+    const key = getRunDate(run).toISOString().slice(0, 10);
+    const existing = map.get(key) ?? [];
+    existing.push(run);
+    map.set(key, existing);
+  }
+  return map;
+}
+
+export function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function getCalendarMonthDays(year: number, month: number): (Date | null)[] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const leadingEmpty = firstDay.getDay();
+  const days: (Date | null)[] = Array.from({ length: leadingEmpty }, () => null);
+
+  for (let day = 1; day <= lastDay.getDate(); day++) {
+    days.push(new Date(year, month, day));
+  }
+
+  while (days.length % 7 !== 0) {
+    days.push(null);
+  }
+
+  return days;
+}
+
+export const RUN_KIND_STYLES: Record<
+  RunScheduleKind,
+  { badge: string; dot: string; label: string }
+> = {
+  scheduled: {
+    badge: "bg-yellow-100 text-yellow-800 border-yellow-200",
+    dot: "bg-yellow-500",
+    label: "Scheduled",
+  },
+  completed: {
+    badge: "bg-green-100 text-green-800 border-green-200",
+    dot: "bg-green-500",
+    label: "Completed",
+  },
+  failed: {
+    badge: "bg-red-100 text-red-800 border-red-200",
+    dot: "bg-red-500",
+    label: "Failed",
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-config-next": "^14.1.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "jsdom": "^25.0.1",
+        "playwright": "^1.61.1",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "tsx": "^4.19.2",
@@ -6780,6 +6781,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {


### PR DESCRIPTION
Closes #52

---

## Description
Adds a payroll calendar/schedule view showing upcoming and historical payroll runs, with a dedicated run detail page. Payroll administrators previously had no way to see upcoming and past runs in one place at a glance — the API for individual runs already existed (`/api/payroll/[id]`) but had no UI consuming it.

Changes:
- New `/payroll/schedule` page: next-run hero, desktop month calendar, mobile timeline view
- New `/payroll/[id]` page: run detail (fills a gap — the API existed, the UI didn't)
- Sidebar nav link via `next/link`
- Empty state and first-run state handled via mock data variants (`MOCK_PAYROLL_RUNS_EMPTY`, `MOCK_PAYROLL_RUNS_FIRST_RUN`)
- Scheduled vs. completed runs are visually distinct (yellow/clock vs. green/checkmark), matching the existing status-pill pattern already used elsewhere in the app
- 11 new tests (Vitest + Testing Library)

Note: 3 pre-existing test failures in `__tests__/zk.*.test.ts` are unrelated to this change — confirmed they fail identically on a clean `main` checkout (those files use `node:test`, not Vitest, so Vitest loads them but finds no registered suite). New payroll tests don't import anything from the ZK modules.

**Fixes:** #52

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Unit/Integration Tests — 11 new tests covering desktop/mobile rendering split, empty state, first-run state, scheduled vs. completed visual distinction, and upcoming-before-past ordering. `typecheck` and `test` both pass.
- [ ] Local manual testing — Visual verification was done via rendered DOM output (Testing Library) rather than live browser screenshots; the app's Freighter wallet-connect auth wall blocked manual browser QA in this session. Recommend a reviewer with Freighter set up do a quick visual pass before merge.
- [ ] Verified on local Soroban/Stellar testnet — not applicable, this is a UI-only change against existing mock data, no on-chain interaction added.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new linting warnings or TypeScript errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes