### PR TITLE
feat(dashboard): admin overview, incident banners, bulk status update, exceptions queue

### DIFF
--- a/__tests__/admin-overview.test.tsx
+++ b/__tests__/admin-overview.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminOverview from '@/components/features/admin/AdminOverview';
+
+describe('AdminOverview', () => {
+  it('renders the section heading', () => {
+    render(<AdminOverview />);
+    expect(screen.getByRole('region', { name: /admin overview/i })).toBeInTheDocument();
+    expect(screen.getByText('Admin Overview')).toBeInTheDocument();
+  });
+
+  it('renders company status card', () => {
+    render(<AdminOverview />);
+    expect(screen.getByText('Company status')).toBeInTheDocument();
+  });
+
+  it('renders treasury balance card', () => {
+    render(<AdminOverview />);
+    expect(screen.getByText('Treasury balance')).toBeInTheDocument();
+  });
+
+  it('renders active employees card', () => {
+    render(<AdminOverview />);
+    expect(screen.getByText('Active employees')).toBeInTheDocument();
+  });
+
+  it('renders pending actions card', () => {
+    render(<AdminOverview />);
+    expect(screen.getByText('Pending actions')).toBeInTheDocument();
+  });
+
+  it('links treasury card to /history', () => {
+    render(<AdminOverview />);
+    const links = screen.getAllByRole('link', { name: /view details/i });
+    const hrefs = links.map((l) => l.getAttribute('href'));
+    expect(hrefs).toContain('/history');
+  });
+
+  it('links employees card to /employees', () => {
+    render(<AdminOverview />);
+    const links = screen.getAllByRole('link', { name: /view details/i });
+    const hrefs = links.map((l) => l.getAttribute('href'));
+    expect(hrefs).toContain('/employees');
+  });
+
+  it('renders 4 stat cards on a desktop-like layout', () => {
+    render(<AdminOverview />);
+    const links = screen.getAllByRole('link', { name: /view details/i });
+    expect(links.length).toBe(4);
+  });
+});

--- a/__tests__/bulk-status-update.test.tsx
+++ b/__tests__/bulk-status-update.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BulkStatusUpdate from '@/components/features/employees/BulkStatusUpdate';
+
+describe('BulkStatusUpdate', () => {
+  it('renders the section heading', () => {
+    render(<BulkStatusUpdate />);
+    expect(screen.getByText('Bulk employee status update')).toBeInTheDocument();
+  });
+
+  it('renders employee rows', () => {
+    render(<BulkStatusUpdate />);
+    expect(screen.getByText('Alice Mensah')).toBeInTheDocument();
+    expect(screen.getByText('Kwame Asante')).toBeInTheDocument();
+  });
+
+  it('select-all checkbox selects all employees', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    const rowChecks = screen.getAllByRole('checkbox', { name: /select /i });
+    rowChecks.forEach((c) => expect(c).toBeChecked());
+  });
+
+  it('individual row checkbox toggles selection', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    const alice = screen.getByRole('checkbox', { name: /select alice mensah/i });
+    await user.click(alice);
+    expect(alice).toBeChecked();
+    await user.click(alice);
+    expect(alice).not.toBeChecked();
+  });
+
+  it('Review changes button is disabled when nothing selected', () => {
+    render(<BulkStatusUpdate />);
+    expect(screen.getByRole('button', { name: /review changes/i })).toBeDisabled();
+  });
+
+  it('Review changes button enables when employee is selected', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    expect(screen.getByRole('button', { name: /review changes/i })).not.toBeDisabled();
+  });
+
+  it('shows confirmation step after clicking Review changes', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    await user.click(screen.getByRole('button', { name: /review changes/i }));
+    expect(screen.getByText(/confirm bulk update/i)).toBeInTheDocument();
+    expect(screen.getByText('Alice Mensah')).toBeInTheDocument();
+  });
+
+  it('back button returns to selection step', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    await user.click(screen.getByRole('button', { name: /review changes/i }));
+    await user.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByText('Bulk employee status update')).toBeInTheDocument();
+  });
+
+  it('shows result step after confirming', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    await user.click(screen.getByRole('button', { name: /review changes/i }));
+    await user.click(screen.getByRole('button', { name: /apply changes/i }));
+    expect(screen.getByText(/update complete/i)).toBeInTheDocument();
+  });
+
+  it('done button resets to selection step', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    await user.click(screen.getByRole('button', { name: /review changes/i }));
+    await user.click(screen.getByRole('button', { name: /apply changes/i }));
+    await user.click(screen.getByRole('button', { name: /done/i }));
+    expect(screen.getByText('Bulk employee status update')).toBeInTheDocument();
+  });
+
+  it('target status dropdown defaults to active', () => {
+    render(<BulkStatusUpdate />);
+    const select = screen.getByRole('combobox', { name: /target status/i }) as HTMLSelectElement;
+    expect(select.value).toBe('active');
+  });
+
+  it('selected count updates as rows are toggled', async () => {
+    const user = userEvent.setup();
+    render(<BulkStatusUpdate />);
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+    await user.click(screen.getByRole('checkbox', { name: /select alice mensah/i }));
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+  });
+});

--- a/__tests__/incident-banner.test.tsx
+++ b/__tests__/incident-banner.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IncidentBanner } from '@/components/ui/IncidentBanner';
+
+describe('IncidentBanner', () => {
+  it('renders a warning banner with correct message', () => {
+    render(<IncidentBanner variant="warning" message="Low treasury balance" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Low treasury balance')).toBeInTheDocument();
+  });
+
+  it('renders an error banner', () => {
+    render(<IncidentBanner variant="error" message="Submission failed" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Submission failed')).toBeInTheDocument();
+  });
+
+  it('renders a maintenance banner', () => {
+    render(<IncidentBanner variant="maintenance" message="Scheduled downtime" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled downtime')).toBeInTheDocument();
+  });
+
+  it('does not render a dismiss button when dismissible is false', () => {
+    render(<IncidentBanner variant="warning" message="msg" dismissible={false} />);
+    expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a dismiss button when dismissible is true', () => {
+    render(<IncidentBanner variant="warning" message="msg" dismissible />);
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
+  });
+
+  it('hides the banner after clicking dismiss', async () => {
+    const user = userEvent.setup();
+    render(<IncidentBanner variant="warning" message="dismiss me" dismissible />);
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('calls onDismiss callback when dismissed', async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(<IncidentBanner variant="error" message="msg" dismissible onDismiss={onDismiss} />);
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('banner remains visible when not dismissed', () => {
+    render(<IncidentBanner variant="maintenance" message="still here" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/__tests__/payroll-exceptions.test.tsx
+++ b/__tests__/payroll-exceptions.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PayrollExceptionsQueue from '@/components/features/payroll/PayrollExceptionsQueue';
+
+describe('PayrollExceptionsQueue', () => {
+  it('renders the section heading', () => {
+    render(<PayrollExceptionsQueue />);
+    expect(
+      screen.getByRole('region', { name: /payroll exceptions/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders exception items from mock data', () => {
+    render(<PayrollExceptionsQueue />);
+    // At least one pending/failed tx from MOCK_TRANSACTIONS
+    const items = screen.queryAllByRole('listitem');
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('shows reason code for each exception', () => {
+    render(<PayrollExceptionsQueue />);
+    expect(screen.getAllByText(/reason:/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows next step for each exception', () => {
+    render(<PayrollExceptionsQueue />);
+    expect(screen.getAllByText(/payroll wizard/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows pending badge for pending transactions', () => {
+    render(<PayrollExceptionsQueue />);
+    expect(screen.getAllByText(/pending/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows count badge in heading', () => {
+    render(<PayrollExceptionsQueue />);
+    const badge = screen.getByText(/^\d+$/);
+    expect(Number(badge.textContent)).toBeGreaterThan(0);
+  });
+
+  it('renders link to payroll wizard for each item', () => {
+    render(<PayrollExceptionsQueue />);
+    const links = screen.getAllByRole('link', { name: /go to payroll wizard/i });
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((l) => expect(l).toHaveAttribute('href', '/payroll'));
+  });
+
+  it('renders exception list with accessible label', () => {
+    render(<PayrollExceptionsQueue />);
+    expect(screen.getByRole('list', { name: /exceptions queue/i })).toBeInTheDocument();
+  });
+});

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,12 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import AdminOverview from "@/components/features/admin/AdminOverview";
+
+function AdminPage() {
+  return (
+    <DashboardLayout>
+      <AdminOverview />
+    </DashboardLayout>
+  );
+}
+
+export default AdminPage;

--- a/app/employees/bulk/page.tsx
+++ b/app/employees/bulk/page.tsx
@@ -1,0 +1,12 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import BulkStatusUpdate from "@/components/features/employees/BulkStatusUpdate";
+
+function BulkUpdatePage() {
+  return (
+    <DashboardLayout>
+      <BulkStatusUpdate />
+    </DashboardLayout>
+  );
+}
+
+export default BulkUpdatePage;

--- a/app/incidents/page.tsx
+++ b/app/incidents/page.tsx
@@ -1,0 +1,23 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import { IncidentBanner } from "@/components/ui/IncidentBanner";
+
+function IncidentsPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-gray-900">System notices</h2>
+        <IncidentBanner
+          variant="maintenance"
+          message="Scheduled maintenance window: 02:00–04:00 UTC. Payroll submissions will be queued."
+          dismissible
+        />
+        <IncidentBanner
+          variant="warning"
+          message="Treasury balance is below the recommended buffer. Fund your account before next payroll."
+        />
+      </div>
+    </DashboardLayout>
+  );
+}
+
+export default IncidentsPage;

--- a/app/payroll/exceptions/page.tsx
+++ b/app/payroll/exceptions/page.tsx
@@ -1,0 +1,12 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import PayrollExceptionsQueue from "@/components/features/payroll/PayrollExceptionsQueue";
+
+function ExceptionsPage() {
+  return (
+    <DashboardLayout>
+      <PayrollExceptionsQueue />
+    </DashboardLayout>
+  );
+}
+
+export default ExceptionsPage;

--- a/components/features/admin/AdminOverview.tsx
+++ b/components/features/admin/AdminOverview.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo } from "react";
+import { Building2, Users, DollarSign, AlertTriangle, ArrowRight } from "lucide-react";
+import { useCompanyStore } from "@/stores/company";
+import { useEmployeeStore } from "@/stores/employees";
+import {
+  MOCK_COMPANIES,
+  MOCK_EMPLOYEES,
+  MOCK_TREASURY_BALANCE,
+  MOCK_TRANSACTIONS,
+} from "@/lib/api/mockData";
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  href,
+  accent,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  sub?: string;
+  href?: string;
+  accent?: "green" | "yellow" | "red";
+}) {
+  const accentClass =
+    accent === "green"
+      ? "text-green-600"
+      : accent === "yellow"
+        ? "text-yellow-600"
+        : accent === "red"
+          ? "text-red-600"
+          : "text-indigo-600";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-500">{label}</span>
+        <Icon className={`h-5 w-5 ${accentClass}`} aria-hidden />
+      </div>
+      <p className="text-2xl font-semibold text-gray-900">{value}</p>
+      {sub && <p className="text-xs text-gray-500">{sub}</p>}
+      {href && (
+        <a
+          href={href}
+          className="flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline"
+        >
+          View details <ArrowRight className="h-3 w-3" />
+        </a>
+      )}
+    </div>
+  );
+}
+
+export default function AdminOverview() {
+  const { company: storedCompany } = useCompanyStore();
+  const { employees: storedEmployees } = useEmployeeStore();
+
+  const company = storedCompany ?? MOCK_COMPANIES[0];
+  const employees = storedEmployees.length > 0 ? storedEmployees : MOCK_EMPLOYEES;
+  const treasury = MOCK_TREASURY_BALANCE;
+
+  const activeCount = useMemo(
+    () => employees.filter((e) => e.isActive).length,
+    [employees],
+  );
+
+  const pendingCount = useMemo(
+    () =>
+      MOCK_TRANSACTIONS.filter((tx) => tx.status === "pending").length,
+    [],
+  );
+
+  const surplus = treasury.balance - treasury.projectedPayroll;
+  const treasuryStatus: "green" | "yellow" | "red" =
+    surplus >= 10_000 ? "green" : surplus >= 0 ? "yellow" : "red";
+
+  return (
+    <section aria-labelledby="admin-overview-heading">
+      <h2 id="admin-overview-heading" className="mb-6 text-xl font-semibold text-gray-900">
+        Admin Overview
+      </h2>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={Building2}
+          label="Company status"
+          value={company?.isActive ? "Active" : "Inactive"}
+          sub={company?.name}
+          accent={company?.isActive ? "green" : "red"}
+          href="/compliance"
+        />
+
+        <StatCard
+          icon={DollarSign}
+          label="Treasury balance"
+          value={`$${treasury.balance.toLocaleString()}`}
+          sub={`Projected payroll $${treasury.projectedPayroll.toLocaleString()}`}
+          accent={treasuryStatus}
+          href="/history"
+        />
+
+        <StatCard
+          icon={Users}
+          label="Active employees"
+          value={String(activeCount)}
+          sub={`${employees.length} total`}
+          accent="green"
+          href="/employees"
+        />
+
+        <StatCard
+          icon={AlertTriangle}
+          label="Pending actions"
+          value={String(pendingCount)}
+          sub={pendingCount > 0 ? "Requires attention" : "All clear"}
+          accent={pendingCount > 0 ? "yellow" : "green"}
+          href="/payroll"
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/features/employees/BulkStatusUpdate.tsx
+++ b/components/features/employees/BulkStatusUpdate.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useEmployeeStore } from "@/stores/employees";
+import { MOCK_EMPLOYEES } from "@/lib/api/mockData";
+import type { Employee } from "@/types";
+
+type TargetStatus = "active" | "inactive" | "pending";
+
+type RowResult = { id: string; name: string; success: boolean; error?: string };
+
+function deriveStatus(e: Employee): "active" | "inactive" | "pending" {
+  if (e.status) return e.status;
+  return e.isActive ? "active" : "inactive";
+}
+
+export default function BulkStatusUpdate() {
+  const { employees: stored, updateEmployee } = useEmployeeStore();
+  const employees = stored.length > 0 ? stored : MOCK_EMPLOYEES;
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [targetStatus, setTargetStatus] = useState<TargetStatus>("active");
+  const [step, setStep] = useState<"select" | "confirm" | "result">("select");
+  const [results, setResults] = useState<RowResult[]>([]);
+
+  const selectedEmployees = useMemo(
+    () => employees.filter((e) => selected.has(e.id)),
+    [employees, selected],
+  );
+
+  function toggleAll() {
+    if (selected.size === employees.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(employees.map((e) => e.id)));
+    }
+  }
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  function handleConfirm() {
+    const rows: RowResult[] = selectedEmployees.map((e) => {
+      try {
+        updateEmployee(e.id, {
+          status: targetStatus,
+          isActive: targetStatus === "active",
+        });
+        return { id: e.id, name: e.name, success: true };
+      } catch (err) {
+        return {
+          id: e.id,
+          name: e.name,
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error",
+        };
+      }
+    });
+    setResults(rows);
+    setStep("result");
+  }
+
+  if (step === "confirm") {
+    return (
+      <section aria-labelledby="bulk-confirm-heading" className="rounded-lg bg-white p-6 shadow-sm">
+        <h3 id="bulk-confirm-heading" className="text-base font-semibold text-gray-900">
+          Confirm bulk update
+        </h3>
+        <p className="mt-2 text-sm text-gray-600">
+          Set {selectedEmployees.length} employee(s) to{" "}
+          <strong className="capitalize">{targetStatus}</strong>?
+        </p>
+        <ul className="mt-3 max-h-48 overflow-y-auto divide-y divide-gray-100 rounded border text-sm">
+          {selectedEmployees.map((e) => (
+            <li key={e.id} className="flex items-center justify-between px-3 py-2">
+              <span>{e.name}</span>
+              <span className="text-xs text-gray-400 capitalize">{deriveStatus(e)} → {targetStatus}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-4 flex gap-3">
+          <button
+            onClick={() => setStep("select")}
+            className="rounded-md border px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            Back
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            Apply changes
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  if (step === "result") {
+    const failed = results.filter((r) => !r.success);
+    return (
+      <section aria-labelledby="bulk-result-heading" className="rounded-lg bg-white p-6 shadow-sm">
+        <h3 id="bulk-result-heading" className="text-base font-semibold text-gray-900">
+          Update complete
+        </h3>
+        <p className="mt-1 text-sm text-gray-600">
+          {results.filter((r) => r.success).length} updated, {failed.length} failed.
+        </p>
+        {failed.length > 0 && (
+          <ul className="mt-3 space-y-1 text-sm text-red-700">
+            {failed.map((r) => (
+              <li key={r.id} role="alert">
+                {r.name}: {r.error}
+              </li>
+            ))}
+          </ul>
+        )}
+        <button
+          onClick={() => {
+            setSelected(new Set());
+            setStep("select");
+          }}
+          className="mt-4 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Done
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="bulk-select-heading" className="rounded-lg bg-white p-6 shadow-sm">
+      <h3 id="bulk-select-heading" className="text-base font-semibold text-gray-900">
+        Bulk employee status update
+      </h3>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <label className="text-sm font-medium text-gray-700">Set status to</label>
+        <select
+          value={targetStatus}
+          onChange={(e) => setTargetStatus(e.target.value as TargetStatus)}
+          className="rounded-md border px-3 py-1.5 text-sm text-gray-700"
+          aria-label="target status"
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+          <option value="pending">Pending</option>
+        </select>
+      </div>
+
+      <div className="mt-4 overflow-hidden rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left text-xs text-gray-500">
+            <tr>
+              <th className="px-4 py-2.5">
+                <input
+                  type="checkbox"
+                  aria-label="Select all employees"
+                  checked={selected.size === employees.length && employees.length > 0}
+                  onChange={toggleAll}
+                />
+              </th>
+              <th className="px-4 py-2.5">Name</th>
+              <th className="px-4 py-2.5">Department</th>
+              <th className="px-4 py-2.5">Current status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {employees.map((e) => (
+              <tr key={e.id} className="hover:bg-gray-50">
+                <td className="px-4 py-2.5">
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${e.name}`}
+                    checked={selected.has(e.id)}
+                    onChange={() => toggle(e.id)}
+                  />
+                </td>
+                <td className="px-4 py-2.5 font-medium text-gray-900">{e.name}</td>
+                <td className="px-4 py-2.5 text-gray-500">{e.department ?? "—"}</td>
+                <td className="px-4 py-2.5 capitalize text-gray-700">{deriveStatus(e)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between">
+        <span className="text-sm text-gray-500">{selected.size} selected</span>
+        <button
+          disabled={selected.size === 0}
+          onClick={() => setStep("confirm")}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+        >
+          Review changes
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/features/payroll/PayrollExceptionsQueue.tsx
+++ b/components/features/payroll/PayrollExceptionsQueue.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useMemo } from "react";
+import { AlertCircle, Clock, XCircle, ArrowRight } from "lucide-react";
+import { MOCK_TRANSACTIONS, MOCK_EMPLOYEES } from "@/lib/api/mockData";
+import type { PayrollTransaction } from "@/types";
+
+type ExceptionItem = {
+  tx: PayrollTransaction;
+  employeeNames: string[];
+  reasonCode: string;
+  nextStep: string;
+};
+
+const REASON_CODES: Record<PayrollTransaction["status"], string> = {
+  pending: "Awaiting ZK proof generation",
+  failed: "Transaction submission failed",
+  verified: "",
+};
+
+const NEXT_STEPS: Record<PayrollTransaction["status"], string> = {
+  pending: "Trigger proof generation or check wallet connectivity",
+  failed: "Review transaction hash and retry via payroll wizard",
+  verified: "",
+};
+
+const STATUS_ICONS: Record<string, React.ElementType> = {
+  pending: Clock,
+  failed: XCircle,
+};
+
+const STATUS_CLASSES: Record<string, string> = {
+  pending: "text-yellow-600",
+  failed: "text-red-600",
+};
+
+export default function PayrollExceptionsQueue() {
+  const exceptions = useMemo<ExceptionItem[]>(() => {
+    return MOCK_TRANSACTIONS.filter(
+      (tx) => tx.status === "pending" || tx.status === "failed",
+    ).map((tx) => ({
+      tx,
+      employeeNames: MOCK_EMPLOYEES.slice(0, tx.employeeCount).map((e) => e.name),
+      reasonCode: REASON_CODES[tx.status],
+      nextStep: NEXT_STEPS[tx.status],
+    }));
+  }, []);
+
+  if (exceptions.length === 0) {
+    return (
+      <section
+        aria-labelledby="exceptions-heading"
+        className="rounded-lg bg-white p-6 shadow-sm"
+      >
+        <h2 id="exceptions-heading" className="text-base font-semibold text-gray-900">
+          Payroll exceptions
+        </h2>
+        <p className="mt-3 text-sm text-gray-500">No exceptions — all payroll items are clear.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="exceptions-heading" className="rounded-lg bg-white p-6 shadow-sm">
+      <h2 id="exceptions-heading" className="mb-4 text-base font-semibold text-gray-900">
+        Payroll exceptions{" "}
+        <span className="ml-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+          {exceptions.length}
+        </span>
+      </h2>
+
+      <ul className="space-y-3" aria-label="exceptions queue">
+        {exceptions.map(({ tx, employeeNames, reasonCode, nextStep }) => {
+          const Icon = STATUS_ICONS[tx.status] ?? AlertCircle;
+          const colorClass = STATUS_CLASSES[tx.status] ?? "text-gray-600";
+
+          return (
+            <li
+              key={tx.id}
+              className="flex flex-col gap-2 rounded-lg border border-gray-200 p-4"
+            >
+              <div className="flex items-start gap-3">
+                <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-gray-900">
+                      Payroll run {tx.id}
+                    </span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${
+                        tx.status === "failed"
+                          ? "bg-red-100 text-red-700"
+                          : "bg-yellow-100 text-yellow-700"
+                      }`}
+                    >
+                      {tx.status}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    ${tx.totalAmount.toLocaleString()} · {tx.employeeCount} employee(s) ·{" "}
+                    {new Date(tx.timestamp).toLocaleDateString()}
+                  </p>
+                  {employeeNames.length > 0 && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      {employeeNames.join(", ")}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="ml-7 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-700">
+                <span className="font-medium">Reason: </span>
+                {reasonCode}
+              </div>
+
+              <div className="ml-7 flex items-center gap-1 text-xs text-indigo-600">
+                <ArrowRight className="h-3 w-3" aria-hidden />
+                <span>{nextStep}</span>
+              </div>
+
+              <div className="ml-7">
+                <a
+                  href="/payroll"
+                  className="text-xs font-medium text-indigo-600 hover:underline"
+                >
+                  Go to payroll wizard →
+                </a>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/components/ui/IncidentBanner.tsx
+++ b/components/ui/IncidentBanner.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, XCircle, Wrench, X } from "lucide-react";
+
+export type BannerVariant = "warning" | "error" | "maintenance";
+
+export type BannerProps = {
+  variant: BannerVariant;
+  message: string;
+  /** When true the user can dismiss the banner */
+  dismissible?: boolean;
+  /** Callback fired after the banner is dismissed */
+  onDismiss?: () => void;
+};
+
+const VARIANT_STYLES: Record<BannerVariant, { bg: string; text: string; border: string }> = {
+  warning: {
+    bg: "bg-yellow-50",
+    text: "text-yellow-800",
+    border: "border-yellow-300",
+  },
+  error: {
+    bg: "bg-red-50",
+    text: "text-red-800",
+    border: "border-red-300",
+  },
+  maintenance: {
+    bg: "bg-blue-50",
+    text: "text-blue-800",
+    border: "border-blue-300",
+  },
+};
+
+const VARIANT_ICONS: Record<BannerVariant, React.ElementType> = {
+  warning: AlertTriangle,
+  error: XCircle,
+  maintenance: Wrench,
+};
+
+const VARIANT_LABELS: Record<BannerVariant, string> = {
+  warning: "Warning",
+  error: "Error",
+  maintenance: "Maintenance",
+};
+
+export function IncidentBanner({ variant, message, dismissible = false, onDismiss }: BannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const styles = VARIANT_STYLES[variant];
+  const Icon = VARIANT_ICONS[variant];
+
+  if (dismissed) return null;
+
+  function handleDismiss() {
+    setDismissed(true);
+    onDismiss?.();
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-label={`${VARIANT_LABELS[variant]}: ${message}`}
+      className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${styles.bg} ${styles.text} ${styles.border}`}
+    >
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+      <span className="flex-1 text-sm font-medium">{message}</span>
+      {dismissible && (
+        <button
+          aria-label="Dismiss banner"
+          onClick={handleDismiss}
+          className="shrink-0 opacity-70 hover:opacity-100"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **#77** — `components/features/admin/AdminOverview.tsx` — 4-card summary grid: company status (active/inactive with compliance link), treasury balance vs projected payroll (color-coded surplus/risk), active employee count, pending payroll action count; each card links into the relevant workflow; page wired at `/admin`; 8 unit tests.
- **#78** — `components/ui/IncidentBanner.tsx` — reusable alert component with `warning`, `error`, and `maintenance` variants; optional `dismissible` prop with `onDismiss` callback; banner disappears after dismiss click; page wired at `/incidents`; 8 unit tests.
- **#79** — `components/features/employees/BulkStatusUpdate.tsx` — 3-step flow: (1) select employees + target status, (2) review/confirm screen listing transitions, (3) result screen with per-row error surfacing; page wired at `/employees/bulk`; 10 unit tests covering all steps and edge cases.
- **#80** — `components/features/payroll/PayrollExceptionsQueue.tsx` — filters pending/failed transactions from mock data into an exceptions queue; each item shows a reason code, next-step guidance, and a link to the payroll wizard; accessible `role="list"` with `aria-label`; page wired at `/payroll/exceptions`; 8 unit tests.

## Test plan

- `vitest run` passes for all 4 new test files in `__tests__/`.
- All tests use mock data — no network calls or database required.

closes #77
closes #78
closes #79
closes #80