### PR TITLE
Add wallet network mismatch handling

### DIFF
--- a/__tests__/smoke/wallet-connection.test.tsx
+++ b/__tests__/smoke/wallet-connection.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/components/providers/StellarProvider", () => ({
     disconnect: vi.fn(),
     isFreighterInstalled: true,
   }),
+  EXPECTED_NETWORK: "TESTNET",
 }));
 
 beforeEach(() => {
@@ -50,5 +51,30 @@ describe("Smoke: Wallet Connection", () => {
     render(<WalletConnect />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText("Connection rejected")).toBeInTheDocument();
+  });
+
+  it("shows a Wrong Network badge when connected to a network other than EXPECTED_NETWORK", () => {
+    useWalletStore.setState({
+      isConnected: true,
+      publicKey: "GBXTQW2V3MHZLZ5K2JZ29MQJ3DQJ29MQJ3DQJ29MQJ29MQJ29MQJ29MQ",
+      network: "PUBLIC",
+    });
+
+    render(<WalletConnect />);
+
+    expect(screen.getByText("Wrong Network")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/wrong network/i);
+  });
+
+  it("does not show the Wrong Network badge when connected to the expected network", () => {
+    useWalletStore.setState({
+      isConnected: true,
+      publicKey: "GBXTQW2V3MHZLZ5K2JZ29MQJ3DQJ29MQJ3DQJ29MQJ29MQJ29MQJ29MQ",
+      network: "TESTNET",
+    });
+
+    render(<WalletConnect />);
+
+    expect(screen.queryByText("Wrong Network")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/wallet-network-env.test.tsx
+++ b/__tests__/wallet-network-env.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// ── Mock Freighter API / Stellar SDK ────────────────────────────────────────
+// Mirrors __tests__/network-guard.test.tsx so StellarProvider can be imported
+// without touching the real Freighter extension or Soroban RPC.
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn().mockResolvedValue({ isConnected: false }),
+  isAllowed: vi.fn().mockResolvedValue({ isAllowed: false }),
+  setAllowed: vi.fn().mockResolvedValue({ isAllowed: false }),
+  getAddress: vi.fn().mockResolvedValue({ address: null, error: "not connected" }),
+  getNetwork: vi
+    .fn()
+    .mockResolvedValue({ network: "TESTNET", networkPassphrase: "Test SDF Network ; September 2015" }),
+  signTransaction: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Contract: vi.fn(),
+  TransactionBuilder: vi.fn(),
+  BASE_FEE: "100",
+}));
+
+vi.mock("@stellar/stellar-sdk/rpc", () => ({
+  Api: { isSimulationError: vi.fn().mockReturnValue(false) },
+  assembleTransaction: vi.fn(),
+  Server: vi.fn(),
+}));
+
+// This suite is isolated in its own file because each test calls
+// vi.resetModules() to force StellarProvider's module-level EXPECTED_NETWORK
+// constant to be recomputed against a different process.env value. Running
+// that alongside tests that rely on a stable module registry (e.g. tests
+// that mutate the real useWalletStore singleton) would make those tests
+// see a different store instance than the one components resolve at render.
+
+describe("Wallet Network Mismatch Detection: EXPECTED_NETWORK sourced from environment", () => {
+  const ORIGINAL_NETWORK_ENV = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+
+  afterEach(() => {
+    if (ORIGINAL_NETWORK_ENV === undefined) {
+      delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+    } else {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = ORIGINAL_NETWORK_ENV;
+    }
+  });
+
+  it("reads the expected network from NEXT_PUBLIC_STELLAR_NETWORK when set to a supported value", async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "PUBLIC";
+
+    const { EXPECTED_NETWORK } = await import("@/components/providers/StellarProvider");
+
+    expect(EXPECTED_NETWORK).toBe("PUBLIC");
+  });
+
+  it("defaults to TESTNET when NEXT_PUBLIC_STELLAR_NETWORK is unset", async () => {
+    vi.resetModules();
+    delete process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+
+    const { EXPECTED_NETWORK } = await import("@/components/providers/StellarProvider");
+
+    expect(EXPECTED_NETWORK).toBe("TESTNET");
+  });
+
+  it("defaults to TESTNET when NEXT_PUBLIC_STELLAR_NETWORK holds an unsupported value", async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "DEVNET";
+
+    const { EXPECTED_NETWORK } = await import("@/components/providers/StellarProvider");
+
+    expect(EXPECTED_NETWORK).toBe("TESTNET");
+  });
+});

--- a/__tests__/wallet-network-mismatch.test.tsx
+++ b/__tests__/wallet-network-mismatch.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { useWalletStore } from "@/stores/walletStore";
+
+// ── Mock Freighter API / Stellar SDK ────────────────────────────────────────
+// Mirrors __tests__/network-guard.test.tsx so StellarProvider (imported
+// transitively by PayrollWizard) can load without touching the real
+// Freighter extension or Soroban RPC.
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn().mockResolvedValue({ isConnected: false }),
+  isAllowed: vi.fn().mockResolvedValue({ isAllowed: false }),
+  setAllowed: vi.fn().mockResolvedValue({ isAllowed: false }),
+  getAddress: vi.fn().mockResolvedValue({ address: null, error: "not connected" }),
+  getNetwork: vi
+    .fn()
+    .mockResolvedValue({ network: "TESTNET", networkPassphrase: "Test SDF Network ; September 2015" }),
+  signTransaction: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Contract: vi.fn(),
+  TransactionBuilder: vi.fn().mockImplementation(() => ({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({ toXDR: () => "mock-xdr" }),
+  })),
+  BASE_FEE: "100",
+}));
+
+vi.mock("@stellar/stellar-sdk/rpc", () => ({
+  Api: { isSimulationError: vi.fn().mockReturnValue(false) },
+  assembleTransaction: vi.fn().mockReturnValue({ build: () => ({ toXDR: () => "mock-xdr" }) }),
+  Server: vi.fn().mockImplementation(() => ({
+    getAccount: vi.fn().mockResolvedValue({ accountId: "GXXX", sequence: "0" }),
+    simulateTransaction: vi.fn().mockResolvedValue({ result: {} }),
+    sendTransaction: vi.fn().mockResolvedValue({ hash: "mock-hash" }),
+  })),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// EXPECTED_NETWORK resolution from NEXT_PUBLIC_STELLAR_NETWORK is covered in
+// __tests__/wallet-network-env.test.tsx. This file assumes the default
+// (unset env -> TESTNET) and asserts the PayrollWizard warning/blocking UI
+// against the real useWalletStore singleton.
+
+describe("Wallet Network Mismatch Detection: PayrollWizard warning and blocking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWalletStore.getState().reset();
+  });
+
+  it("shows a persistent warning banner naming both networks when the wallet is on the wrong network", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+
+    useWalletStore.setState({ network: "PUBLIC" });
+
+    render(<PayrollWizard />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/wallet network mismatch/i);
+    expect(alert).toHaveTextContent("PUBLIC");
+    expect(alert).toHaveTextContent("TESTNET");
+  });
+
+  it("does not show the warning banner when the wallet is on the expected network", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+
+    useWalletStore.setState({ network: "TESTNET" });
+
+    render(<PayrollWizard />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("disables the Start Payroll Run action while the mismatch exists", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+
+    useWalletStore.setState({ network: "PUBLIC" });
+
+    render(<PayrollWizard />);
+
+    expect(screen.getByRole("button", { name: /start payroll run/i })).toBeDisabled();
+  });
+
+  it("disables Generate Proof while the mismatch exists", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+    const { usePayrollWizardStore } = await import("@/stores/payrollWizard");
+
+    useWalletStore.setState({ network: "PUBLIC" });
+    usePayrollWizardStore.setState({
+      currentStep: "proof",
+      employeeIds: ["emp_001"],
+      totalAmount: 1000,
+    });
+
+    render(<PayrollWizard />);
+
+    expect(screen.getByRole("button", { name: /generate proof/i })).toBeDisabled();
+
+    usePayrollWizardStore.getState().reset();
+  });
+
+  it("recovers correctly after switching to the right network: banner clears and actions re-enable", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+
+    useWalletStore.setState({ network: "PUBLIC" });
+
+    render(<PayrollWizard />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start payroll run/i })).toBeDisabled();
+
+    act(() => {
+      useWalletStore.setState({ network: "TESTNET" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /start payroll run/i })).not.toBeDisabled();
+  });
+
+  it("disables Retry Submission on the submit step while the mismatch exists", async () => {
+    const PayrollWizard = (await import("@/components/features/payroll/PayrollWizard")).default;
+    const { usePayrollWizardStore } = await import("@/stores/payrollWizard");
+
+    useWalletStore.setState({ network: "TESTNET" });
+    usePayrollWizardStore.setState({
+      currentStep: "submit",
+      employeeIds: ["emp_001", "emp_002"],
+      totalAmount: 9500,
+      submissionStatus: "error",
+      submissionError: "Submission failed: network timeout.",
+    });
+
+    render(<PayrollWizard />);
+
+    const retryBtn = screen.getByRole("button", { name: /retry submission/i });
+    expect(retryBtn).not.toBeDisabled();
+
+    act(() => {
+      useWalletStore.setState({ network: "PUBLIC" });
+    });
+
+    await waitFor(() => {
+      expect(retryBtn).toBeDisabled();
+    });
+
+    usePayrollWizardStore.getState().reset();
+  });
+});

--- a/components/features/payroll/PayrollWizard.tsx
+++ b/components/features/payroll/PayrollWizard.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { usePayrollWizardStore } from "@/stores/payrollWizard";
 import { useWalletStore } from "@/stores/walletStore";
 import { EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
+import { IncidentBanner } from "@/components/ui/IncidentBanner";
 import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
 import PayrollReceipt from "./PayrollReceipt";
 import type { PayrollWizardStep } from "@/types";
@@ -86,6 +87,13 @@ function PayrollWizard() {
   }, [setEmployeeIds, setTotalAmount]);
 
   const handleGenerateProof = useCallback(async () => {
+    if (isWrongNetwork) {
+      toast.error("Wrong network", {
+        description: `Switch your wallet to ${EXPECTED_NETWORK} to continue.`,
+      });
+      return;
+    }
+
     setProofStatus("generating");
     setProofError(null);
 
@@ -109,9 +117,16 @@ function PayrollWizard() {
         description: "Circuit constraint mismatch.",
       });
     }
-  }, [setProofStatus, setProofError, nextStep]);
+  }, [setProofStatus, setProofError, nextStep, isWrongNetwork]);
 
   const handleSubmit = useCallback(async () => {
+    if (isWrongNetwork) {
+      toast.error("Wrong network", {
+        description: `Switch your wallet to ${EXPECTED_NETWORK} to continue.`,
+      });
+      return;
+    }
+
     setSubmissionStatus("submitting");
     setSubmissionError(null);
     nextStep();
@@ -138,7 +153,7 @@ function PayrollWizard() {
         description: "Network timeout. The transaction may still be processing.",
       });
     }
-  }, [setSubmissionStatus, setSubmissionError, setTransactionHash, nextStep]);
+  }, [setSubmissionStatus, setSubmissionError, setTransactionHash, nextStep, isWrongNetwork]);
 
   const idx = stepIndex(currentStep);
 
@@ -147,6 +162,13 @@ function PayrollWizard() {
       <h2 id="payroll-wizard-heading" className="text-lg font-semibold text-gray-900">
         Execute Payroll
       </h2>
+
+      {isWrongNetwork && (
+        <IncidentBanner
+          variant="warning"
+          message={`Wallet network mismatch: your wallet is connected to ${network}, but this app requires ${EXPECTED_NETWORK}. Switch networks in your wallet to resume payroll actions.`}
+        />
+      )}
 
       {showDraftBanner && (
         <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-start gap-3">
@@ -276,6 +298,7 @@ function PayrollWizard() {
             employeeCount={employeeIds.length}
             onRetry={handleSubmit}
             onReset={reset}
+            isWrongNetwork={isWrongNetwork}
           />
         )}
       </div>
@@ -510,6 +533,7 @@ function SubmitStep({
   employeeCount,
   onRetry,
   onReset,
+  isWrongNetwork,
 }: {
   status: "idle" | "submitting" | "success" | "error";
   error: string | null;
@@ -518,6 +542,7 @@ function SubmitStep({
   employeeCount: number;
   onRetry: () => void;
   onReset: () => void;
+  isWrongNetwork: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -550,7 +575,9 @@ function SubmitStep({
             <button
               type="button"
               onClick={onRetry}
-              className="px-4 py-2 rounded-md bg-red-50 text-red-700 text-sm font-medium hover:bg-red-100 border border-red-200 transition-colors inline-flex items-center gap-1"
+              disabled={isWrongNetwork}
+              title={isWrongNetwork ? `Switch to ${EXPECTED_NETWORK} in your wallet` : undefined}
+              className="px-4 py-2 rounded-md bg-red-50 text-red-700 text-sm font-medium hover:bg-red-100 border border-red-200 transition-colors inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <RotateCcw className="w-3.5 h-3.5" />
               Retry Submission

--- a/components/features/wallet/WalletConnect.tsx
+++ b/components/features/wallet/WalletConnect.tsx
@@ -9,8 +9,9 @@ import {
   ExternalLink,
   LogOut,
   Check,
+  AlertTriangle,
 } from "lucide-react";
-import { useStellar } from "@/components/providers/StellarProvider";
+import { useStellar, EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
 import { useWalletStore } from "@/stores/walletStore";
 
 // Truncates a Stellar public key for display: GBXT...J29M
@@ -104,6 +105,7 @@ function WalletConnect() {
   // ── Stellar Expert URL ──────────────────────────────────────────────────────
   const network = useWalletStore((s) => s.network);
   const networkStr = typeof network === "string" ? network.toLowerCase() : "testnet";
+  const isWrongNetwork = isConnected && network !== EXPECTED_NETWORK;
   const stellarExpertUrl = publicKey
     ? `https://stellar.expert/explorer/${networkStr}/account/${publicKey}`
     : "#";
@@ -141,18 +143,35 @@ function WalletConnect() {
           <button
             ref={triggerRef}
             onClick={() => setDropdownOpen((prev) => !prev)}
-            className="inline-flex items-center gap-2.5 px-4 py-2.5 rounded-lg font-medium text-gray-900 bg-white border border-gray-200 hover:bg-gray-50 active:bg-gray-100 transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none shadow-sm"
+            className={`inline-flex items-center gap-2.5 px-4 py-2.5 rounded-lg font-medium bg-white border transition-colors focus-visible:ring-2 focus-visible:outline-none shadow-sm ${
+              isWrongNetwork
+                ? "text-amber-900 border-amber-300 hover:bg-amber-50 active:bg-amber-100 focus-visible:ring-amber-500"
+                : "text-gray-900 border-gray-200 hover:bg-gray-50 active:bg-gray-100 focus-visible:ring-indigo-500"
+            }`}
             aria-haspopup="true"
             aria-expanded={dropdownOpen}
             aria-controls="wallet-dropdown"
-            aria-label={`Wallet menu for ${truncateKey(publicKey)}`}
+            aria-label={
+              isWrongNetwork
+                ? `Wallet menu for ${truncateKey(publicKey)}, connected to the wrong network`
+                : `Wallet menu for ${truncateKey(publicKey)}`
+            }
           >
-            {/* Green status dot */}
-            <span className="relative flex h-2.5 w-2.5" aria-hidden="true">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-green-500" />
-            </span>
+            {isWrongNetwork ? (
+              <AlertTriangle className="h-3.5 w-3.5 text-amber-600 shrink-0" aria-hidden="true" />
+            ) : (
+              /* Green status dot */
+              <span className="relative flex h-2.5 w-2.5" aria-hidden="true">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-green-500" />
+              </span>
+            )}
             <span className="font-mono text-sm">{truncateKey(publicKey)}</span>
+            {isWrongNetwork && (
+              <span className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                Wrong Network
+              </span>
+            )}
             <ChevronDown
               className={`w-4 h-4 text-gray-400 transition-transform ${
                 dropdownOpen ? "rotate-180" : ""
@@ -218,7 +237,9 @@ function WalletConnect() {
         {isLoading
           ? "Connecting wallet"
           : isConnected && publicKey
-            ? `Wallet connected: ${truncateKey(publicKey)}`
+            ? isWrongNetwork
+              ? `Wallet connected: ${truncateKey(publicKey)}, but on the wrong network. Switch to ${EXPECTED_NETWORK} to continue.`
+              : `Wallet connected: ${truncateKey(publicKey)}`
             : "Wallet disconnected"}
       </span>
 

--- a/components/providers/StellarProvider.tsx
+++ b/components/providers/StellarProvider.tsx
@@ -43,9 +43,32 @@ const NETWORK_CONFIG: Record<
     },
 };
 
-export const EXPECTED_NETWORK: StellarNetwork = 'TESTNET';
+const CONFIGURABLE_NETWORKS: StellarNetwork[] = ['TESTNET', 'PUBLIC'];
+const DEFAULT_NETWORK: StellarNetwork = 'TESTNET';
 
 const log = createLogger('StellarProvider');
+
+// Resolves the network this app is configured to run against from
+// NEXT_PUBLIC_STELLAR_NETWORK. Falls back to TESTNET when the variable is
+// unset or holds an unsupported value, so a misconfigured deployment degrades
+// to the safest default instead of crashing the client bundle.
+function resolveExpectedNetwork(): StellarNetwork {
+    const configured = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+
+    if (configured && CONFIGURABLE_NETWORKS.includes(configured as StellarNetwork)) {
+        return configured as StellarNetwork;
+    }
+
+    if (configured) {
+        log.warn('NEXT_PUBLIC_STELLAR_NETWORK has an unsupported value; defaulting to TESTNET', {
+            value: configured,
+        });
+    }
+
+    return DEFAULT_NETWORK;
+}
+
+export const EXPECTED_NETWORK: StellarNetwork = resolveExpectedNetwork();
 
 // ─── Context Types ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #150

## Summary

Detects when the connected wallet's network doesn't match the network this deployment is configured for, and blocks payroll actions until the mismatch is resolved.

The repo already had a wrong-network detection foundation (`StellarProvider`, `WalletErrorOverlay`, disabled buttons in `PayrollWizard`) from a previous PR. This PR closes the remaining gaps called out in the issue:

- The "expected network" was hardcoded (`EXPECTED_NETWORK = 'TESTNET'`) instead of read from environment configuration.
- There was no persistent, always-visible warning once the blocking modal was dismissed — only a hover tooltip on disabled buttons.
- The action handlers relied solely on the `disabled` attribute; there was no guard at the point of action itself.

## Changes

### Modified files

- **`components/providers/StellarProvider.tsx`** — `EXPECTED_NETWORK` is now resolved from `NEXT_PUBLIC_STELLAR_NETWORK` via a new `resolveExpectedNetwork()` helper. Falls back to `TESTNET` (with a `log.warn`) when the variable is unset or holds an unsupported value, so a misconfigured deployment degrades safely instead of crashing the client bundle.
- **`components/features/payroll/PayrollWizard.tsx`** —
  - Renders a persistent `IncidentBanner` (reusing the existing `components/ui/IncidentBanner.tsx`) naming both the wallet's current network and the expected one whenever `isWrongNetwork` is true, so the warning stays visible even after the modal overlay is dismissed.
  - `handleGenerateProof` and `handleSubmit` now check `isWrongNetwork` at the start and short-circuit with a `toast.error` instead of proceeding, as defense-in-depth alongside the existing `disabled` attributes.
  - The `SubmitStep`'s "Retry Submission" button is now also disabled while the mismatch exists (previously only the initial submit button was gated).
- **`components/features/wallet/WalletConnect.tsx`** — the connected-wallet pill in the header now shows an amber "Wrong Network" badge (with an `AlertTriangle` icon replacing the green status dot) when `network !== EXPECTED_NETWORK`, and the screen-reader status text announces the mismatch. This keeps the warning visible globally, not just within the payroll wizard.

### New files (tests)

- **`__tests__/wallet-network-env.test.tsx`** — verifies `EXPECTED_NETWORK` is read from `NEXT_PUBLIC_STELLAR_NETWORK` when set to a supported value, and falls back to `TESTNET` when the variable is unset or holds an unsupported value. Isolated in its own file because it uses `vi.resetModules()` per test to force re-evaluation of the module-level constant against different `process.env` values; mixing that with tests that rely on a stable module registry (e.g. asserting against the real `useWalletStore` singleton) caused cross-test pollution.
- **`__tests__/wallet-network-mismatch.test.tsx`** — covers the `PayrollWizard` warning/blocking UI against the real `useWalletStore`: the banner appears/disappears based on network match, `Start Payroll Run` / `Generate Proof` / `Retry Submission` are disabled while mismatched, and the UI recovers (banner clears, buttons re-enable) after switching `useWalletStore`'s `network` back to the expected value.

### Modified test file

- **`__tests__/smoke/wallet-connection.test.tsx`** — added `EXPECTED_NETWORK: "TESTNET"` to the existing `StellarProvider` mock (now required since `WalletConnect` imports it), plus two new cases asserting the "Wrong Network" badge shows/hides correctly based on the connected network.

## Implementation details

- The expected-network resolution lives in `StellarProvider.tsx` rather than a new shared env module, to avoid importing `lib/env.ts` (which validates server-only secrets like `SESSION_SECRET`) into a client component — that would crash the client bundle since those vars aren't `NEXT_PUBLIC_`-prefixed and therefore aren't inlined into client JS.
- Existing network-change detection (Freighter polling every 2s, `syncNetworkFromFreighter`, the blocking `WalletErrorOverlay` modal, and the `signTx`/`invokeContract` guards) was left as-is — this PR builds on top of it rather than replacing it.

## Tests

- `npx vitest run` — all tests pass except 4 pre-existing failures on `main` unrelated to this change (a `Math.random()`-based flake in two mocked submission/proof tests, and one pre-existing `role-based-access` failure), confirmed by running the same suite on `main` before this branch's changes.
- `npx eslint` on all changed files — clean.
- `npx next build` — compiles successfully. `tsc`/`next build` type-checking fails on an unrelated, pre-existing file-casing collision (`components/ui/badge.tsx` vs `Badge.tsx`) that also fails identically on `main`.

## How to test

1. `pnpm install && pnpm dev` (or `npm install && npm run dev`).
2. Set `NEXT_PUBLIC_STELLAR_NETWORK=TESTNET` in `.env.local` (see `.env.example`).
3. Connect a Freighter wallet set to a different network (e.g. Public/Mainnet) and navigate to `/payroll/execute`.
4. Verify:
   - A warning banner appears above the wizard steps naming both the wallet's network and the required network.
   - The wallet pill in the header shows an amber "Wrong Network" badge.
   - "Start Payroll Run" (and, once a run is in progress, "Generate Proof" / "Submit Payroll" / "Retry Submission") are disabled.
5. Switch Freighter back to the configured network (no page reload needed — polling picks it up within ~2s):
   - The warning banner disappears.
   - The "Wrong Network" badge disappears.
   - Payroll actions re-enable.
6. Automated coverage: `npx vitest run __tests__/wallet-network-env.test.tsx __tests__/wallet-network-mismatch.test.tsx __tests__/smoke/wallet-connection.test.tsx __tests__/network-guard.test.tsx`
