### PR TITLE
test: add wallet connect interaction test (#153)

### DIFF
--- a/__tests__/smoke/wallet-connection.test.tsx
+++ b/__tests__/smoke/wallet-connection.test.tsx
@@ -3,25 +3,47 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import WalletConnect from "@/components/features/wallet/WalletConnect";
 import { useWalletStore } from "@/stores/walletStore";
 
+const mockConnect = vi.fn();
+const mockDisconnect = vi.fn();
+
 vi.mock("@/components/providers/StellarProvider", () => ({
   useStellar: () => ({
-    connect: vi.fn(),
-    disconnect: vi.fn(),
+    connect: mockConnect,
+    disconnect: mockDisconnect,
     isFreighterInstalled: true,
   }),
   EXPECTED_NETWORK: "TESTNET",
 }));
 
 beforeEach(() => {
+  mockConnect.mockReset();
+  mockDisconnect.mockReset();
   useWalletStore.getState().reset();
 });
 
 describe("Smoke: Wallet Connection", () => {
   it("renders connect button when disconnected", () => {
     render(<WalletConnect />);
+
     expect(
-      screen.getByRole("button", { name: /connect freighter/i }),
+      screen.getByRole("button", {
+        name: /connect freighter/i,
+      }),
     ).toBeInTheDocument();
+  });
+
+  it("calls connect when the connect button is clicked", async () => {
+    render(<WalletConnect />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /connect freighter/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("shows connected state with wallet address", () => {


### PR DESCRIPTION
## Summary

Adds integration test coverage for the dashboard wallet connection flow.

### Changes
- Mocked Stellar wallet provider behavior.
- Verified disconnected state renders the Connect Freighter button.
- Added test to verify clicking the Connect button invokes the wallet provider.
- Verified loading state.
- Verified connected state.
- Verified error toast rendering.
- Verified wrong network badge rendering.
- Verified expected network hides the warning badge.

### Validation

- ✅ Wallet smoke tests pass (7/7)
- ✅ Visual regression tests pass (9 passed, 2 skipped)
- ✅ TypeScript typecheck passes
- ⚠️ Existing ESLint issues are unrelated to this PR and already exist on `main`.

Closes #153
