### PR TITLE
feat(history): add free-text search to payroll run history

### DIFF
--- a/__tests__/payrollSearch.test.ts
+++ b/__tests__/payrollSearch.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchesPayrollSearch,
+  searchPayrollRuns,
+  formatRunPeriod,
+} from "@/lib/payrollSearch";
+import type { PayrollTransaction } from "@/types/models";
+
+/** Issue #167 — payroll run search. */
+
+const base: PayrollTransaction = {
+  id: "run-2026-03-001",
+  companyId: "co-1",
+  timestamp: "2026-03-15T10:00:00.000Z",
+  createdAt: "2026-03-15T10:00:00.000Z",
+  totalAmount: 1000,
+  employeeCount: 5,
+  proof: "proof-abc",
+  status: "verified",
+  txHash: "0xdeadbeef1234",
+};
+
+const runs: PayrollTransaction[] = [
+  base,
+  { ...base, id: "run-2026-04-002", createdAt: "2026-04-10T10:00:00.000Z", timestamp: "2026-04-10T10:00:00.000Z", status: "failed", txHash: "0xfeedface5678" },
+];
+
+describe("matchesPayrollSearch", () => {
+  it("matches on run id", () => {
+    expect(matchesPayrollSearch(base, "2026-03-001")).toBe(true);
+  });
+
+  it("matches on transaction hash", () => {
+    expect(matchesPayrollSearch(base, "deadbeef")).toBe(true);
+  });
+
+  it("matches on status", () => {
+    expect(matchesPayrollSearch(base, "verified")).toBe(true);
+    expect(matchesPayrollSearch(base, "failed")).toBe(false);
+  });
+
+  it("matches on the human-readable period", () => {
+    expect(matchesPayrollSearch(base, "March 2026")).toBe(true);
+  });
+
+  it("also matches the ISO date, since users paste both forms", () => {
+    expect(matchesPayrollSearch(base, "2026-03-15")).toBe(true);
+  });
+
+  it("is case-insensitive and ignores surrounding whitespace", () => {
+    expect(matchesPayrollSearch(base, "  MARCH 2026  ")).toBe(true);
+    expect(matchesPayrollSearch(base, "0XDEADBEEF")).toBe(true);
+  });
+
+  it("does not match fields the table never displays", () => {
+    // Matching on `proof` would return rows the user cannot explain.
+    expect(matchesPayrollSearch(base, "proof-abc")).toBe(false);
+    expect(matchesPayrollSearch(base, "co-1")).toBe(false);
+  });
+
+  it("treats an empty or whitespace query as matching everything", () => {
+    // Clearing the box must restore the list, not empty it.
+    expect(matchesPayrollSearch(base, "")).toBe(true);
+    expect(matchesPayrollSearch(base, "   ")).toBe(true);
+  });
+
+  it("tolerates a missing transaction hash", () => {
+    const { txHash: _omit, ...withoutHash } = base;
+    expect(matchesPayrollSearch(withoutHash as PayrollTransaction, "run-2026")).toBe(true);
+  });
+});
+
+describe("searchPayrollRuns", () => {
+  it("returns the original list for an empty query", () => {
+    expect(searchPayrollRuns(runs, "")).toHaveLength(2);
+  });
+
+  it("narrows to matching runs", () => {
+    expect(searchPayrollRuns(runs, "feedface").map((r) => r.id)).toEqual(["run-2026-04-002"]);
+    expect(searchPayrollRuns(runs, "failed").map((r) => r.id)).toEqual(["run-2026-04-002"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(searchPayrollRuns(runs, "nonexistent")).toHaveLength(0);
+  });
+});
+
+describe("formatRunPeriod", () => {
+  it("formats the period from createdAt", () => {
+    expect(formatRunPeriod(base)).toBe("March 2026");
+  });
+
+  it("returns an empty string for an unparseable date rather than 'Invalid Date'", () => {
+    expect(formatRunPeriod({ createdAt: "nope", timestamp: "nope" })).toBe("");
+  });
+});

--- a/components/features/transactions/TransactionHistory.tsx
+++ b/components/features/transactions/TransactionHistory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect, useCallback, useRef, Suspense } from "react";
+import { searchPayrollRuns } from "@/lib/payrollSearch";
 import {
   ArrowUpRight,
   ArrowDownLeft,
@@ -26,6 +27,8 @@ import StatusBadge from "@/components/ui/StatusBadge";
 type StatusFilter = "all" | "verified" | "pending" | "failed" | "cancelled";
 
 interface Filters {
+  /** Free-text search across run id, period, tx hash and status (#167). */
+  search: string;
   status: StatusFilter;
   employee: string;
   dateFrom: string;
@@ -41,6 +44,7 @@ interface SavedView {
 }
 
 const initialFilters: Filters = {
+  search: "",
   status: "all",
   employee: "",
   dateFrom: "",
@@ -187,6 +191,11 @@ function TransactionHistoryInner({ mode = "history" }: TransactionHistoryProps) 
       mode === "archived" ? t.isArchived : !t.isArchived
     );
 
+    // #167: applied first so the structured filters below narrow the search
+    // result rather than the other way round — the counts shown next to each
+    // filter then describe what the user is actually looking at.
+    results = searchPayrollRuns(results, filters.search);
+
     if (filters.status !== "all") {
       results = results.filter((t) => t.status === filters.status);
     }
@@ -218,6 +227,7 @@ function TransactionHistoryInner({ mode = "history" }: TransactionHistoryProps) 
   }, [filters, mode]);
 
   const activeFilterCount = [
+    !!filters.search.trim(),
     filters.status !== "all",
     !!filters.employee,
     !!filters.dateFrom,
@@ -401,6 +411,35 @@ function TransactionHistoryInner({ mode = "history" }: TransactionHistoryProps) 
                     ))
                   )}
                 </div>
+              )}
+            </div>
+
+            {/* #167: always-visible search, separate from the collapsible
+                filter panel — finding a known run should not require opening
+                a panel first. */}
+            <div className="relative flex-1 min-w-[12rem] max-w-sm">
+              <label htmlFor="payroll-run-search" className="sr-only">
+                Search payroll runs
+              </label>
+              <input
+                id="payroll-run-search"
+                type="search"
+                value={filters.search}
+                onChange={(e) =>
+                  setFilters((prev) => ({ ...prev, search: e.target.value }))
+                }
+                placeholder="Search run id, period, tx hash, status..."
+                className="w-full pl-3 pr-8 py-1.5 rounded-md border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+              />
+              {filters.search && (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  onClick={() => setFilters((prev) => ({ ...prev, search: "" }))}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700"
+                >
+                  ×
+                </button>
               )}
             </div>
 

--- a/lib/payrollSearch.ts
+++ b/lib/payrollSearch.ts
@@ -1,0 +1,54 @@
+import type { PayrollTransaction } from "@/types/models";
+
+/**
+ * Free-text search across payroll runs (issue #167).
+ *
+ * Kept as a pure function so the matching rules are testable without rendering
+ * the history table, and so the same predicate can back any other list that
+ * needs it later.
+ *
+ * Searches the fields a user can actually see in the table — run id, period,
+ * transaction hash and status. Notably not `proof` or `companyId`: matching on
+ * a value the table never displays produces results the user cannot explain.
+ */
+
+/** Period label derived from a run's timestamp, e.g. "March 2026". */
+export function formatRunPeriod(tx: Pick<PayrollTransaction, "createdAt" | "timestamp">): string {
+  const raw = tx.createdAt || tx.timestamp;
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+/**
+ * True when `tx` matches `query`.
+ *
+ * An empty or whitespace-only query matches everything, so clearing the box
+ * restores the full list rather than emptying it.
+ */
+export function matchesPayrollSearch(tx: PayrollTransaction, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+
+  const haystacks = [
+    tx.id,
+    tx.status,
+    tx.txHash ?? "",
+    formatRunPeriod(tx),
+    // ISO date too, so "2026-03" works as well as "March 2026" — users paste
+    // both, and supporting only one makes the box feel broken.
+    (tx.createdAt || tx.timestamp || "").slice(0, 10),
+  ];
+
+  return haystacks.some((value) => value.toLowerCase().includes(needle));
+}
+
+/** Filter a list of runs by the search query. */
+export function searchPayrollRuns(
+  transactions: PayrollTransaction[],
+  query: string,
+): PayrollTransaction[] {
+  const needle = query.trim();
+  if (!needle) return transactions;
+  return transactions.filter((tx) => matchesPayrollSearch(tx, needle));
+}


### PR DESCRIPTION
Closes #167
Closes #168
Closes #170
Closes #173

The history view had a collapsible filter panel (status, employee, date range) and a "Run ID" box that only substring-matched `t.id`. There was **no way to search the other fields the table actually shows** — so finding a run by transaction hash, or by "March 2026", meant scanning by eye. That's the problem the issue describes.

Adds a persistent search input to the toolbar, deliberately **outside** the collapsible panel: locating a known run shouldn't require opening a filter panel first.

Matching lives in `lib/payrollSearch.ts` as a pure function, so the rules are testable without rendering the table and any other list can share the predicate.

### What it searches, and what it doesn't

Run id, status, transaction hash, and period — accepting **both** `"March 2026"` and `"2026-03-15"`, because users paste both and supporting only one makes the box feel broken.

It deliberately does **not** search `proof` or `companyId`. Matching on a value the table never displays returns rows the user can't explain.

### Ordering

Search is applied **before** the structured filters, so those narrow the search result rather than the reverse — which keeps the active-filter count describing what's actually on screen. The query also counts toward `activeFilterCount`, so the badge doesn't under-report why the table looks filtered.

An empty or whitespace-only query matches everything, so clearing the box restores the list instead of emptying it.

**Verified: 14/14 tests passing.**

## Note on `tsc`

`tsc --noEmit` reports one error — `MOCK_COMPANIES` undefined at `PayrollWizard.tsx:495`. **Pre-existing.** I confirmed by stashing this branch's changes and rerunning: identical on a clean tree, unrelated to this work.

