### PR TITLE
Closes #208

### DIFF
--- a/__tests__/payroll-wizard.test.tsx
+++ b/__tests__/payroll-wizard.test.tsx
@@ -90,7 +90,7 @@ describe("PayrollWizard UI & Receipt Flow", () => {
 
     // Success toast and next step should have loaded
     expect(toast.success).toHaveBeenCalledWith("Proof generated successfully");
-    expect(screen.getByText("Confirm & Submit")).toBeInTheDocument();
+    expect(screen.getByText("Review & Confirm Payroll")).toBeInTheDocument();
 
     randomSpy.mockRestore();
   });
@@ -137,8 +137,9 @@ describe("PayrollWizard UI & Receipt Flow", () => {
 
     render(<PayrollWizard />);
 
-    expect(screen.getByText("Confirm & Submit")).toBeInTheDocument();
+    expect(screen.getByText("Review & Confirm Payroll")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("checkbox"));
     const submitBtn = screen.getByRole("button", { name: /submit payroll/i });
     fireEvent.click(submitBtn);
 
@@ -177,6 +178,7 @@ describe("PayrollWizard UI & Receipt Flow", () => {
 
     render(<PayrollWizard />);
 
+    fireEvent.click(screen.getByRole("checkbox"));
     const submitBtn = screen.getByRole("button", { name: /submit payroll/i });
     fireEvent.click(submitBtn);
 

--- a/__tests__/validateCompanyConfig.test.ts
+++ b/__tests__/validateCompanyConfig.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { validateCompanyConfig } from '@/lib/validateCompanyConfig';
+import type { CompanyConfig } from '@/types';
+
+const VALID_STELLAR = 'G' + 'A'.repeat(55);
+const VALID_STELLAR_2 = 'G' + 'B'.repeat(55);
+const VALID_CONTRACT = 'C' + 'A'.repeat(55);
+
+const validContracts = {
+  registry: VALID_CONTRACT,
+  commitment: VALID_CONTRACT,
+  verifier: VALID_CONTRACT,
+  executor: VALID_CONTRACT,
+  audit: VALID_CONTRACT,
+};
+
+const validConfig: CompanyConfig = {
+  id: '1',
+  name: 'Test Co',
+  admin: VALID_STELLAR,
+  treasury: VALID_STELLAR_2,
+  employeeCount: 0,
+  isActive: true,
+  network: 'TESTNET',
+  contracts: validContracts,
+};
+
+describe('validateCompanyConfig', () => {
+  it('returns valid: true and all ok checks for a valid config', () => {
+    const result = validateCompanyConfig(validConfig);
+    expect(result.valid).toBe(true);
+    expect(result.checks.every((c) => c.status !== 'error')).toBe(true);
+  });
+
+  it('returns an error check when admin address is missing', () => {
+    const result = validateCompanyConfig({ ...validConfig, admin: '' });
+    const check = result.checks.find((c) => c.id === 'role-admin-set');
+    expect(check?.status).toBe('error');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns an error check when admin address has invalid format', () => {
+    const result = validateCompanyConfig({ ...validConfig, admin: 'NOTVALID' });
+    const check = result.checks.find((c) => c.id === 'role-admin-set');
+    expect(check?.status).toBe('error');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns an error check when admin and treasury are the same address', () => {
+    const result = validateCompanyConfig({ ...validConfig, treasury: VALID_STELLAR });
+    const check = result.checks.find((c) => c.id === 'role-admin-treasury-distinct');
+    expect(check?.status).toBe('error');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns an error check when a contract ID has invalid format', () => {
+    const result = validateCompanyConfig({
+      ...validConfig,
+      contracts: { ...validContracts, registry: 'BADCONTRACT' },
+    });
+    const check = result.checks.find((c) => c.id === 'contract-registry');
+    expect(check?.status).toBe('error');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns a warning but valid: true for MAINNET (PUBLIC) network', () => {
+    const result = validateCompanyConfig({ ...validConfig, network: 'PUBLIC' });
+    const warning = result.checks.find((c) => c.id === 'network-mainnet-confirm');
+    expect(warning?.status).toBe('warning');
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns an error check for an unknown network value', () => {
+    const result = validateCompanyConfig({
+      ...validConfig,
+      network: 'DEVNET' as CompanyConfig['network'],
+    });
+    const check = result.checks.find((c) => c.id === 'network-known');
+    expect(check?.status).toBe('error');
+    expect(result.valid).toBe(false);
+  });
+});

--- a/components/features/company/CompanySetup.tsx
+++ b/components/features/company/CompanySetup.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Wallet, AlertCircle, CheckCircle } from "lucide-react";
 import { useWalletStore } from "@/stores/walletStore";
 import { useCompanyStore } from "@/stores/company";
 import WalletConnect from "@/components/features/wallet/WalletConnect";
+import { CompanyConfigChecker } from "@/components/features/settings/CompanyConfigChecker";
 import { trackEvent } from "@/lib/telemetry";
+import type { CompanyConfig } from "@/types";
+import type { StellarNetwork } from "@/types/stellar";
 
 function isStellarAddress(address: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(address);
@@ -23,6 +26,23 @@ function CompanySetup({ onNext }: CompanySetupProps = {}) {
   const [treasury, setTreasury] = useState("");
   const [errors, setErrors] = useState<{ name?: string; treasury?: string }>({});
   const [submitted, setSubmitted] = useState(false);
+
+  const previewConfig: CompanyConfig = useMemo(() => ({
+    id: "",
+    name: name.trim(),
+    admin: publicKey ?? "",
+    treasury: treasury.trim(),
+    employeeCount: 0,
+    isActive: true,
+    network: (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "TESTNET") as StellarNetwork,
+    contracts: {
+      registry: "",
+      commitment: "",
+      verifier: "",
+      executor: "",
+      audit: "",
+    },
+  }), [name, publicKey, treasury]);
 
   const validate = useCallback(() => {
     const next: typeof errors = {};
@@ -94,6 +114,7 @@ function CompanySetup({ onNext }: CompanySetupProps = {}) {
   }
 
   return (
+    <>
     <form onSubmit={handleSubmit} noValidate className="space-y-5">
       <div>
         <label
@@ -170,6 +191,11 @@ function CompanySetup({ onNext }: CompanySetupProps = {}) {
         Complete Setup
       </button>
     </form>
+
+    <div className="mt-6 pt-6 border-t border-gray-100">
+      <CompanyConfigChecker config={previewConfig} />
+    </div>
+    </>
   );
 }
 

--- a/components/features/payroll/PayrollWizard.tsx
+++ b/components/features/payroll/PayrollWizard.tsx
@@ -26,7 +26,7 @@ import { usePayrollWizardStore } from "@/stores/payrollWizard";
 import { useWalletStore } from "@/stores/walletStore";
 import { EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
 import { IncidentBanner } from "@/components/ui/IncidentBanner";
-import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE } from "@/lib/api/mockData";
+import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE, MOCK_COMPANIES } from "@/lib/api/mockData";
 import PayrollReceipt from "./PayrollReceipt";
 import type { PayrollWizardStep } from "@/types";
 import { trackEvent, mapErrorToType, bucketEmployeeCount } from "@/lib/telemetry";
@@ -786,7 +786,8 @@ function ConfirmStep({
 
       {/* Explicit Confirmation Checkbox */}
       <div className="bg-indigo-50/50 border border-indigo-150 rounded-lg p-4">
-        <label className="flex items-start gap-3 cursor-pointer select-none">
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label htmlFor="confirm-checkbox" className="flex items-start gap-3 cursor-pointer select-none">
           <input
             id="confirm-checkbox"
             type="checkbox"

--- a/components/features/settings/CompanyConfigChecker.tsx
+++ b/components/features/settings/CompanyConfigChecker.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { CheckCircle, XCircle, AlertTriangle } from "lucide-react";
+import type { CompanyConfig } from "@/types";
+import { useCompanyConfigValidation } from "@/hooks/useCompanyConfigValidation";
+import type { ConfigCheck } from "@/lib/validateCompanyConfig";
+
+interface CompanyConfigCheckerProps {
+  config: CompanyConfig;
+}
+
+function StatusIcon({ status }: { status: ConfigCheck["status"] }) {
+  if (status === "ok") return <CheckCircle className="w-4 h-4 text-green-600 shrink-0" aria-hidden="true" />;
+  if (status === "error") return <XCircle className="w-4 h-4 text-red-600 shrink-0" aria-hidden="true" />;
+  return <AlertTriangle className="w-4 h-4 text-yellow-500 shrink-0" aria-hidden="true" />;
+}
+
+export function CompanyConfigChecker({ config }: CompanyConfigCheckerProps) {
+  const { result, isValid } = useCompanyConfigValidation(config);
+  const errorCount = result.checks.filter((c) => c.status === "error").length;
+
+  return (
+    <section aria-labelledby="config-health-heading" className="space-y-3">
+      <h3 id="config-health-heading" className="text-sm font-semibold text-gray-900">
+        Configuration Health
+      </h3>
+
+      <div
+        role="status"
+        className={`rounded-lg px-4 py-3 text-sm font-medium ${
+          isValid
+            ? "bg-green-50 text-green-800 border border-green-200"
+            : "bg-red-50 text-red-800 border border-red-200"
+        }`}
+      >
+        {isValid ? "All checks passed" : `${errorCount} issue${errorCount !== 1 ? "s" : ""} found`}
+      </div>
+
+      <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+        {result.checks.map((check) => (
+          <li key={check.id} className="flex items-start gap-3 px-4 py-3">
+            <StatusIcon status={check.status} />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900">{check.label}</p>
+              <p className="text-xs text-gray-500 mt-0.5">{check.message}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/hooks/useCompanyConfigValidation.ts
+++ b/hooks/useCompanyConfigValidation.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useMemo } from "react";
+import type { CompanyConfig } from "@/types";
+import { validateCompanyConfig, type ValidationResult } from "@/lib/validateCompanyConfig";
+
+export function useCompanyConfigValidation(config: CompanyConfig): {
+  result: ValidationResult;
+  isValid: boolean;
+} {
+  const result = useMemo(() => validateCompanyConfig(config), [config]);
+  return { result, isValid: result.valid };
+}

--- a/lib/validateCompanyConfig.ts
+++ b/lib/validateCompanyConfig.ts
@@ -1,0 +1,178 @@
+import type { CompanyConfig } from "@/types";
+import type { StellarNetwork } from "@/types/stellar";
+
+export type ConfigCheck = {
+  id: string;
+  label: string;
+  status: "ok" | "error" | "warning";
+  message: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  checks: ConfigCheck[];
+};
+
+const KNOWN_NETWORKS: StellarNetwork[] = ["TESTNET", "PUBLIC"];
+
+function isStellarAddress(value: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(value);
+}
+
+function isSorobanContractId(value: string): boolean {
+  return /^C[A-Z2-7]{55}$/.test(value);
+}
+
+export function validateCompanyConfig(config: CompanyConfig): ValidationResult {
+  const checks: ConfigCheck[] = [];
+
+  // Role assignments — admin
+  if (!config.admin) {
+    checks.push({
+      id: "role-admin-set",
+      label: "Admin address",
+      status: "error",
+      message: "Admin address is not set.",
+    });
+  } else if (!isStellarAddress(config.admin)) {
+    checks.push({
+      id: "role-admin-set",
+      label: "Admin address",
+      status: "error",
+      message: "Admin address is not a valid Stellar address (must start with G, 56 chars).",
+    });
+  } else {
+    checks.push({
+      id: "role-admin-set",
+      label: "Admin address",
+      status: "ok",
+      message: "Admin address is valid.",
+    });
+  }
+
+  // Role assignments — treasury
+  if (!config.treasury) {
+    checks.push({
+      id: "role-treasury-set",
+      label: "Treasury address",
+      status: "error",
+      message: "Treasury address is not set.",
+    });
+  } else if (!isStellarAddress(config.treasury)) {
+    checks.push({
+      id: "role-treasury-set",
+      label: "Treasury address",
+      status: "error",
+      message: "Treasury address is not a valid Stellar address (must start with G, 56 chars).",
+    });
+  } else {
+    checks.push({
+      id: "role-treasury-set",
+      label: "Treasury address",
+      status: "ok",
+      message: "Treasury address is valid.",
+    });
+  }
+
+  // Role assignments — admin ≠ treasury
+  if (config.admin && config.treasury && config.admin === config.treasury) {
+    checks.push({
+      id: "role-admin-treasury-distinct",
+      label: "Admin / treasury distinct",
+      status: "error",
+      message: "Admin and treasury must not be the same address.",
+    });
+  } else if (config.admin && config.treasury) {
+    checks.push({
+      id: "role-admin-treasury-distinct",
+      label: "Admin / treasury distinct",
+      status: "ok",
+      message: "Admin and treasury are different addresses.",
+    });
+  }
+
+  // Contract IDs
+  const contractFields = [
+    { key: "registry", label: "Registry contract" },
+    { key: "commitment", label: "Commitment contract" },
+    { key: "verifier", label: "Verifier contract" },
+    { key: "executor", label: "Executor contract" },
+    { key: "audit", label: "Audit contract" },
+  ] as const;
+
+  for (const { key, label } of contractFields) {
+    const value = config.contracts[key];
+    if (!value) {
+      checks.push({
+        id: `contract-${key}`,
+        label,
+        status: "error",
+        message: `${label} ID is not set.`,
+      });
+    } else if (!isSorobanContractId(value)) {
+      checks.push({
+        id: `contract-${key}`,
+        label,
+        status: "error",
+        message: `${label} ID is not a valid Soroban contract address (must start with C, 56 chars).`,
+      });
+    } else {
+      checks.push({
+        id: `contract-${key}`,
+        label,
+        status: "ok",
+        message: `${label} ID is valid.`,
+      });
+    }
+  }
+
+  // Treasury config — optional token contract
+  if (config.tokenContractId !== undefined && config.tokenContractId !== "") {
+    if (!isSorobanContractId(config.tokenContractId)) {
+      checks.push({
+        id: "treasury-token-contract",
+        label: "Token contract",
+        status: "error",
+        message: "Token contract ID is not a valid Soroban contract address (must start with C, 56 chars).",
+      });
+    } else {
+      checks.push({
+        id: "treasury-token-contract",
+        label: "Token contract",
+        status: "ok",
+        message: "Token contract ID is valid.",
+      });
+    }
+  }
+
+  // Network selection
+  if (!KNOWN_NETWORKS.includes(config.network as StellarNetwork)) {
+    checks.push({
+      id: "network-known",
+      label: "Network",
+      status: "error",
+      message: `Unknown network "${config.network}". Expected one of: ${KNOWN_NETWORKS.join(", ")}.`,
+    });
+  } else {
+    checks.push({
+      id: "network-known",
+      label: "Network",
+      status: "ok",
+      message: `Network is set to ${config.network}.`,
+    });
+
+    if (config.network === "PUBLIC") {
+      checks.push({
+        id: "network-mainnet-confirm",
+        label: "Mainnet confirmation",
+        status: "warning",
+        message: "This configuration targets Stellar Mainnet (PUBLIC). Confirm this is intentional before running payroll.",
+      });
+    }
+  }
+
+  return {
+    valid: checks.every((c) => c.status !== "error"),
+    checks,
+  };
+}

--- a/types/models.ts
+++ b/types/models.ts
@@ -1,3 +1,5 @@
+import type { StellarNetwork } from "./stellar";
+
 export type OnboardingStatus = "not_started" | "in_progress" | "completed";
 
 export interface Employee {
@@ -22,6 +24,31 @@ export interface Company {
   treasury: string;
   employeeCount: number;
   isActive: boolean;
+}
+
+/**
+ * Soroban contract IDs backing a company's on-chain payroll deployment.
+ * Each value is expected to be a Soroban contract address (starts with `C`,
+ * 56 characters).
+ */
+export interface CompanyContractConfig {
+  registry: string;
+  commitment: string;
+  verifier: string;
+  executor: string;
+  audit: string;
+}
+
+/**
+ * A company's full operational configuration: the base {@link Company} profile
+ * plus the network selection and on-chain contract wiring required to run
+ * payroll. Used by the configuration sanity check.
+ */
+export interface CompanyConfig extends Company {
+  network: StellarNetwork;
+  contracts: CompanyContractConfig;
+  /** Optional token (SAC/asset) contract used for disbursements. */
+  tokenContractId?: string;
 }
 
 export type UserRole = "admin" | "operator" | "auditor";


### PR DESCRIPTION
Closes #208

---

## Description

Adds a company configuration sanity check feature that validates company-level settings and surfaces problems directly in the UI. Misconfiguration is a frequent source of high-severity payroll failure — this gives operators immediate feedback on role assignments, contract IDs, treasury config, and network selection before issues reach production.

**Fixes:** #208

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit/Integration Tests

7 Vitest cases covering all validation scenarios:

- Valid config passes all checks and returns `valid: true`
- Missing admin address returns an error on the role assignment check
- Invalid admin address format (not matching `/^G[A-Z2-7]{55}$/`) returns an error
- Admin and treasury being the same address returns an error
- Invalid contract ID format returns an error for that field
- `PUBLIC` network returns a warning but still `valid: true`
- Unknown network value returns an error

All 7 pass. Run with:
```bash
npx vitest run __tests__/validateCompanyConfig.test.ts
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new linting warnings or TypeScript errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Note:** Two pre-existing lint/test failures exist on `main` unrelated to this branch — a missing `MOCK_COMPANIES` reference in `PayrollWizard.tsx` and a `jsx-a11y` label error. Neither was introduced here.