### PR TITLE
 feat: add mobile-safe payroll detail sheet with responsive bottom/right drawer

### DIFF
--- a/__tests__/visual-regression/__snapshots__/payroll-flow-states.test.tsx.snap
+++ b/__tests__/visual-regression/__snapshots__/payroll-flow-states.test.tsx.snap
@@ -1048,12 +1048,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Failed S
               >
                 Failed
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800"
+              <div
+                aria-label="Status: Failed"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-red-100 text-red-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-xcircle w-3.5 h-3.5"
+                  class="lucide lucide-xcircle w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -1076,8 +1078,10 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Failed S
                     d="m9 9 6 6"
                   />
                 </svg>
-                Failed
-              </span>
+                <span>
+                  Failed
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -1534,12 +1538,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Pending 
               >
                 Scheduled
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"
+              <div
+                aria-label="Status: Pending"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-yellow-100 text-yellow-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-clock w-3.5 h-3.5"
+                  class="lucide lucide-clock w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -1559,8 +1565,10 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Pending 
                     points="12 6 12 12 16 14"
                   />
                 </svg>
-                Pending
-              </span>
+                <span>
+                  Pending
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -2021,12 +2029,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Verified
               >
                 Completed
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
+              <div
+                aria-label="Status: Verified"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-green-100 text-green-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-check-circle w-3.5 h-3.5"
+                  class="lucide lucide-check-circle2 w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -2037,15 +2047,19 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Verified
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M22 11.08V12a10 10 0 1 1-5.93-9.14"
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
                   />
                   <path
-                    d="m9 11 3 3L22 4"
+                    d="m9 12 2 2 4-4"
                   />
                 </svg>
-                Verified
-              </span>
+                <span>
+                  Verified
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/components/features/payroll/PayrollCalendar.tsx
+++ b/components/features/payroll/PayrollCalendar.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Calendar,
   CheckCircle,
   ChevronLeft,
   ChevronRight,
+  ChevronRight as ChevronRightIcon,
   Clock,
   XCircle,
 } from "lucide-react";
 import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
 import type { PayrollRun } from "@/types/models";
 import EmptyState from "@/components/ui/EmptyState";
+import PayrollDetailSheet from "@/components/features/payroll/PayrollDetailSheet";
 import {
   classifyRun,
   formatPayrollDate,
@@ -79,6 +81,36 @@ function RunListItem({ run }: { run: PayrollRun }) {
         </div>
         <ChevronRight className="w-4 h-4 text-gray-400 shrink-0 mt-0.5" aria-hidden="true" />
       </Link>
+    </li>
+  );
+}
+
+function MobileRunListItem({ run, onSelect }: { run: PayrollRun; onSelect: (run: PayrollRun) => void }) {
+  const kind = classifyRun(run);
+  const styles = RUN_KIND_STYLES[kind];
+  const date = getRunDate(run);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(run)}
+        className={`w-full flex items-start gap-3 p-4 rounded-lg border transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 text-left ${styles.badge}`}
+      >
+        <RunKindIcon kind={kind} />
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900">
+              {formatPayrollDate(date)}
+            </span>
+            <RunBadge kind={kind} />
+          </div>
+          <p className="text-sm text-gray-600 mt-0.5">
+            ${run.totalAmount.toLocaleString()} · {run.employeeCount} employees
+          </p>
+        </div>
+        <ChevronRightIcon className="w-4 h-4 text-gray-400 shrink-0 mt-0.5" aria-hidden="true" />
+      </button>
     </li>
   );
 }
@@ -245,6 +277,21 @@ function MonthCalendar({
 }
 
 function PayrollCalendar({ runs = MOCK_PAYROLL_RUNS }: PayrollCalendarProps) {
+  const [selectedRun, setSelectedRun] = useState<PayrollRun | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const handleRunSelect = useCallback((run: PayrollRun) => {
+    setSelectedRun(run);
+    setSheetOpen(true);
+  }, []);
+
+  const handleSheetOpenChange = useCallback((open: boolean) => {
+    setSheetOpen(open);
+    if (!open) {
+      setSelectedRun(null);
+    }
+  }, []);
+
   const nextUp = useMemo(() => getNextUpcoming(runs), [runs]);
   const sortedRuns = useMemo(() => sortRunsForSchedule(runs), [runs]);
   const runsByDate = useMemo(() => groupRunsByDateKey(runs), [runs]);
@@ -323,7 +370,7 @@ function PayrollCalendar({ runs = MOCK_PAYROLL_RUNS }: PayrollCalendarProps) {
         </div>
         <ul className="divide-y divide-gray-100 p-3 space-y-2">
           {sortedRuns.map((run) => (
-            <RunListItem key={run.id} run={run} />
+            <MobileRunListItem key={run.id} run={run} onSelect={handleRunSelect} />
           ))}
         </ul>
       </div>
@@ -403,6 +450,12 @@ function PayrollCalendar({ runs = MOCK_PAYROLL_RUNS }: PayrollCalendarProps) {
           </ul>
         </div>
       )}
+
+      <PayrollDetailSheet
+        run={selectedRun}
+        open={sheetOpen}
+        onOpenChange={handleSheetOpenChange}
+      />
     </section>
   );
 }

--- a/components/features/payroll/PayrollDetailSheet.tsx
+++ b/components/features/payroll/PayrollDetailSheet.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import StatusBadge from "@/components/ui/StatusBadge";
+import {
+  classifyRun,
+  formatPayrollDate,
+  getRunDate,
+  RUN_KIND_STYLES,
+} from "@/lib/payroll/scheduleUtils";
+import type { PayrollRun } from "@/types/models";
+import {
+  Calendar,
+  CheckCircle,
+  Clock,
+  EyeOff,
+  FileCode,
+  Shield,
+  Users,
+  XCircle,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { MOCK_EMPLOYEES } from "@/lib/api/mockData";
+
+const STATUS_ICONS: Record<string, LucideIcon> = {
+  verified: CheckCircle,
+  pending: Clock,
+  failed: XCircle,
+  cancelled: XCircle,
+};
+
+interface PayrollDetailSheetProps {
+  run: PayrollRun | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function PayrollDetailSheet({
+  run,
+  open,
+  onOpenChange,
+}: PayrollDetailSheetProps) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const employeesInRun = useMemo(() => {
+    if (!run) return [];
+    return MOCK_EMPLOYEES.filter((e) => run.employeeIds.includes(e.id));
+  }, [run]);
+
+  if (!run) return null;
+
+  const kind = classifyRun(run);
+  const kindStyles = RUN_KIND_STYLES[kind];
+  const runDate = getRunDate(run);
+  const StatusIcon = STATUS_ICONS[run.status] ?? Clock;
+  const txHash = run.transactionHash ?? run.txHash;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side={isMobile ? "bottom" : "right"}
+        className={
+          isMobile
+            ? "flex flex-col h-[85vh] w-full rounded-t-xl"
+            : "flex flex-col w-full sm:max-w-xl"
+        }
+      >
+        <SheetHeader className="shrink-0 space-y-4 pb-6 border-b">
+          <div className="flex items-start gap-3">
+            <div
+              className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 border ${kindStyles.badge}`}
+            >
+              <StatusIcon className="w-5 h-5" aria-hidden="true" />
+            </div>
+            <div className="space-y-1">
+              <SheetTitle className="text-xl">
+                Payroll run &middot; {formatPayrollDate(runDate)}
+              </SheetTitle>
+              <SheetDescription>Run ID: {run.id}</SheetDescription>
+              <div className="flex items-center gap-2 mt-1">
+                <span
+                  className={`inline-flex px-2 py-1 text-xs font-medium rounded-full border ${kindStyles.badge}`}
+                >
+                  {kindStyles.label}
+                </span>
+                <StatusBadge status={run.status} />
+              </div>
+            </div>
+          </div>
+        </SheetHeader>
+
+        <ScrollArea className="flex-1 pr-4">
+          <div className="space-y-6 py-6">
+            <section>
+              <h4 className="text-sm font-semibold text-gray-900 mb-4">
+                Run Metadata
+              </h4>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center gap-1.5 text-gray-500 mb-1">
+                    <Calendar className="w-3.5 h-3.5" aria-hidden="true" />
+                    <span className="text-xs font-medium uppercase">Date</span>
+                  </div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {formatPayrollDate(runDate)}
+                  </p>
+                </div>
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center gap-1.5 text-gray-500 mb-1">
+                    <Users className="w-3.5 h-3.5" aria-hidden="true" />
+                    <span className="text-xs font-medium uppercase">Employees</span>
+                  </div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {run.employeeCount} employees
+                  </p>
+                </div>
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center gap-1.5 text-gray-500 mb-1">
+                    <Shield className="w-3.5 h-3.5" aria-hidden="true" />
+                    <span className="text-xs font-medium uppercase">Total</span>
+                  </div>
+                  <p className="text-sm font-medium text-gray-900">
+                    ${run.totalAmount.toLocaleString()}
+                  </p>
+                </div>
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center gap-1.5 text-gray-500 mb-1">
+                    <FileCode className="w-3.5 h-3.5" aria-hidden="true" />
+                    <span className="text-xs font-medium uppercase">ZK Proof</span>
+                  </div>
+                  <p className="text-sm font-mono text-gray-900 truncate" title={run.proof}>
+                    {run.proof
+                      ? `${run.proof.slice(0, 12)}...${run.proof.slice(-8)}`
+                      : "Pending generation"}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            {txHash && (
+              <section>
+                <h4 className="text-sm font-semibold text-gray-900 mb-2">
+                  Transaction
+                </h4>
+                <p className="font-mono text-xs text-gray-900 break-all bg-gray-50 p-3 rounded-lg">
+                  {txHash}
+                </p>
+              </section>
+            )}
+
+            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4 flex items-start gap-3">
+              <EyeOff className="w-5 h-5 text-indigo-500 mt-0.5 shrink-0" aria-hidden="true" />
+              <div>
+                <h4 className="text-sm font-medium text-indigo-800">Privacy Preserved</h4>
+                <p className="text-sm text-indigo-700 mt-1">
+                  Individual salary amounts are never displayed. Zero-knowledge proofs
+                  verify correctness without revealing sensitive data.
+                </p>
+              </div>
+            </div>
+
+            <section>
+              <h4 className="text-sm font-semibold text-gray-900 mb-4">
+                Employee Results
+              </h4>
+              <p className="text-xs text-gray-500 mb-3">
+                Participation status for each employee in this payroll run.
+              </p>
+              {employeesInRun.length > 0 ? (
+                <div className="divide-y divide-gray-100 border rounded-lg overflow-hidden">
+                  {employeesInRun.map((emp) => (
+                    <div key={emp.id} className="flex items-center justify-between p-3">
+                      <div>
+                        <p className="text-sm font-medium text-gray-900">{emp.name}</p>
+                        {emp.email && (
+                          <p className="text-xs text-gray-500">{emp.email}</p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {run.status === "verified" ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800">
+                            <CheckCircle className="w-3 h-3" aria-hidden="true" />
+                            Included
+                          </span>
+                        ) : run.status === "pending" ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-yellow-100 text-yellow-800">
+                            <Clock className="w-3 h-3" aria-hidden="true" />
+                            Pending
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-red-100 text-red-800">
+                            <XCircle className="w-3 h-3" aria-hidden="true" />
+                            Failed
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500 text-center py-4">
+                  No employee records found for this payroll run.
+                </p>
+              )}
+              <p className="text-xs text-gray-500 mt-2">
+                {employeesInRun.length} employee{employeesInRun.length !== 1 ? "s" : ""} in this run
+              </p>
+            </section>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@rollup/rollup-win32-x64-msvc": "^4.62.3",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.5.0",
         "class-variance-authority": "^0.7.1",
@@ -42,7 +43,7 @@
         "markdownlint-cli": "^0.49.1",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
-        "tsx": "^4.19.2",
+        "tsx": "^4.23.1",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
@@ -555,6 +556,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -571,6 +573,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,6 +590,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -603,6 +607,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -619,6 +624,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,6 +641,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,6 +658,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,6 +675,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,6 +692,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,6 +709,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -715,6 +726,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,6 +743,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,6 +760,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,6 +777,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,6 +794,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -795,6 +811,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -811,6 +828,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -827,6 +845,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,6 +862,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -859,6 +879,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -875,6 +896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -891,6 +913,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -907,6 +930,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,6 +947,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,6 +964,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -955,6 +981,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2141,15 +2168,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ]
@@ -4573,7 +4598,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5503,7 +5528,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8707,7 +8732,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -8806,6 +8831,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -9840,14 +9879,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -9857,6 +9895,464 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@rollup/rollup-win32-x64-msvc": "^4.62.3",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.5.0",
     "class-variance-authority": "^0.7.1",
@@ -50,7 +51,7 @@
     "markdownlint-cli": "^0.49.1",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "tsx": "^4.19.2",
+    "tsx": "^4.23.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   }

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -23,6 +23,21 @@ const localStorageMock = {
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
+// jsdom does not implement matchMedia, which responsive components rely on.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // jsdom does not implement ResizeObserver, which Radix ScrollArea relies on.
 if (typeof globalThis.ResizeObserver === 'undefined') {
   globalThis.ResizeObserver = class {


### PR DESCRIPTION

## Description

Added a mobile-safe payroll detail sheet that displays on small screens as a bottom drawer (using shadcn/ui Sheet with side="bottom") and on desktop as a right panel (side="right"). Previously, tapping a payroll run item on mobile navigated away to a full /payroll/[id] page, breaking the flow. This sheet keeps users in-context by overlaying the detail panel on the schedule view, showing run metadata, transaction hash with clipboard copy, a privacy notice, and a scrollable employee results list.

**Fixes:** #205 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Local manual testing (Please describe)
- [x] Unit/Integration Tests


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new linting warnings or TypeScript errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #205
