### PR TITLE
 feat: add payroll history search and filters to schedule page

### DIFF
--- a/__tests__/payroll-history.test.tsx
+++ b/__tests__/payroll-history.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import PayrollHistory from "@/components/features/payroll/PayrollHistory";
+import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
+
+describe("PayrollHistory", () => {
+  it("renders the calendar heading inside the payroll calendar", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByText("Payroll Schedule")).toBeInTheDocument();
+  });
+
+  it("renders a search input with the expected placeholder", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(
+      screen.getByPlaceholderText(/search run id, period, tx hash, status/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the filter toggle button", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByRole("button", { name: /filter/i })).toBeInTheDocument();
+  });
+
+  it("shows the filter panel when the filter button is clicked", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    expect(screen.getByLabelText("Status")).toBeInTheDocument();
+    expect(screen.getByLabelText("Transaction Outcome")).toBeInTheDocument();
+    expect(screen.getByLabelText("From")).toBeInTheDocument();
+    expect(screen.getByLabelText("To")).toBeInTheDocument();
+  });
+
+  it("hides the filter panel when the filter button is clicked again", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const filterButton = screen.getByRole("button", { name: /filter/i });
+    fireEvent.click(filterButton);
+    expect(screen.getByLabelText("Status")).toBeInTheDocument();
+
+    fireEvent.click(filterButton);
+    expect(screen.queryByLabelText("Status")).not.toBeInTheDocument();
+  });
+
+  it("shows the active filter indicator when a status filter is applied", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    const statusSelect = screen.getByLabelText("Status");
+    fireEvent.change(statusSelect, { target: { value: "verified" } });
+
+    expect(screen.getByText(/1 filter active/i)).toBeInTheDocument();
+  });
+
+  it("narrows results when a search query is typed", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search run id, period, tx hash, status/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "cancelled" } });
+
+    expect(screen.getByText("Payroll Schedule")).toBeInTheDocument();
+  });
+
+  it("shows an active filter count badge on the filter button", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search run id, period, tx hash, status/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "verified" } });
+
+    const filterBtn = screen.getByRole("button", {
+      name: (name) => name.startsWith("Filter"),
+    });
+    expect(within(filterBtn).getByText("1")).toBeInTheDocument();
+  });
+
+  it("shows a clear button when filters are active and clears them on click", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search run id, period, tx hash, status/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "verified" } });
+
+    const clearButton = screen.getByRole("button", { name: /clear all filters/i });
+    expect(clearButton).toBeInTheDocument();
+
+    fireEvent.click(clearButton);
+    expect(searchInput).toHaveValue("");
+  });
+
+  it("shows the filter indicator bar when filters are active", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search run id, period, tx hash, status/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "verified" } });
+
+    expect(screen.getByText(/1 filter active/i)).toBeInTheDocument();
+  });
+
+  it("displays the empty state when no runs match the applied filters", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search run id, period, tx hash, status/i,
+    );
+    fireEvent.change(searchInput, { target: { value: "nonexistent_run_id_xyz" } });
+
+    expect(screen.getByText("No payroll runs yet")).toBeInTheDocument();
+  });
+
+  it("renders the PayrollCalendar and its content inside the history view", () => {
+    render(<PayrollHistory runs={MOCK_PAYROLL_RUNS} />);
+
+    expect(screen.getByText("Past payroll runs")).toBeInTheDocument();
+  });
+});

--- a/__tests__/visual-regression/__snapshots__/payroll-flow-states.test.tsx.snap
+++ b/__tests__/visual-regression/__snapshots__/payroll-flow-states.test.tsx.snap
@@ -1048,12 +1048,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Failed S
               >
                 Failed
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800"
+              <div
+                aria-label="Status: Failed"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-red-100 text-red-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-xcircle w-3.5 h-3.5"
+                  class="lucide lucide-xcircle w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -1076,8 +1078,10 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Failed S
                     d="m9 9 6 6"
                   />
                 </svg>
-                Failed
-              </span>
+                <span>
+                  Failed
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -1534,12 +1538,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Pending 
               >
                 Scheduled
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"
+              <div
+                aria-label="Status: Pending"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-yellow-100 text-yellow-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-clock w-3.5 h-3.5"
+                  class="lucide lucide-clock w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -1559,8 +1565,10 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Pending 
                     points="12 6 12 12 16 14"
                   />
                 </svg>
-                Pending
-              </span>
+                <span>
+                  Pending
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -2021,12 +2029,14 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Verified
               >
                 Completed
               </span>
-              <span
-                class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
+              <div
+                aria-label="Status: Verified"
+                class="focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-green-100 text-green-800 inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border transition-colors"
+                role="status"
               >
                 <svg
                   aria-hidden="true"
-                  class="lucide lucide-check-circle w-3.5 h-3.5"
+                  class="lucide lucide-check-circle2 w-3.5 h-3.5 shrink-0"
                   fill="none"
                   height="24"
                   stroke="currentColor"
@@ -2037,15 +2047,19 @@ exports[`Visual Regression - Payroll Flow States > Payroll Run Detail - Verified
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <path
-                    d="M22 11.08V12a10 10 0 1 1-5.93-9.14"
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
                   />
                   <path
-                    d="m9 11 3 3L22 4"
+                    d="m9 12 2 2 4-4"
                   />
                 </svg>
-                Verified
-              </span>
+                <span>
+                  Verified
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/app/payroll/schedule/page.tsx
+++ b/app/payroll/schedule/page.tsx
@@ -1,10 +1,10 @@
 import DashboardLayout from "@/components/layout/DashboardLayout";
-import PayrollCalendar from "@/components/features/payroll/PayrollCalendar";
+import PayrollHistory from "@/components/features/payroll/PayrollHistory";
 
 function PayrollSchedulePage() {
   return (
     <DashboardLayout>
-      <PayrollCalendar />
+      <PayrollHistory />
     </DashboardLayout>
   );
 }

--- a/components/features/payroll/PayrollHistory.tsx
+++ b/components/features/payroll/PayrollHistory.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Filter, Search, X } from "lucide-react";
+import PayrollCalendar from "./PayrollCalendar";
+import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
+import type { PayrollRun } from "@/types/models";
+import { searchPayrollRuns } from "@/lib/payrollSearch";
+
+type StatusFilter = "all" | "pending" | "verified" | "failed" | "cancelled";
+type OutcomeFilter = "all" | "pending" | "partial" | "complete" | "failed";
+
+interface Filters {
+  search: string;
+  status: StatusFilter;
+  dateFrom: string;
+  dateTo: string;
+  outcome: OutcomeFilter;
+}
+
+interface PayrollHistoryProps {
+  runs?: PayrollRun[];
+}
+
+const initialFilters: Filters = {
+  search: "",
+  status: "all",
+  dateFrom: "",
+  dateTo: "",
+  outcome: "all",
+};
+
+function PayrollHistory({ runs = MOCK_PAYROLL_RUNS }: PayrollHistoryProps) {
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const [showFilters, setShowFilters] = useState(false);
+
+  const filteredRuns = useMemo(() => {
+    let results = runs;
+
+    results = searchPayrollRuns(results, filters.search) as PayrollRun[];
+
+    if (filters.status !== "all") {
+      results = results.filter((r) => r.status === filters.status);
+    }
+
+    if (filters.dateFrom) {
+      results = results.filter((r) => (r.createdAt || "") >= filters.dateFrom);
+    }
+
+    if (filters.dateTo) {
+      results = results.filter((r) => (r.createdAt || "") <= filters.dateTo);
+    }
+
+    if (filters.outcome !== "all") {
+      results = results.filter((r) => r.reconciliationStatus === filters.outcome);
+    }
+
+    return results;
+  }, [runs, filters]);
+
+  const activeFilterCount = [
+    !!filters.search.trim(),
+    filters.status !== "all",
+    !!filters.dateFrom,
+    !!filters.dateTo,
+    filters.outcome !== "all",
+  ].filter(Boolean).length;
+
+  const clearFilters = () => setFilters(initialFilters);
+
+  return (
+    <>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[12rem] max-w-sm">
+          <label htmlFor="payroll-history-search" className="sr-only">
+            Search payroll runs
+          </label>
+          <input
+            id="payroll-history-search"
+            type="search"
+            value={filters.search}
+            onChange={(e) =>
+              setFilters((prev) => ({ ...prev, search: e.target.value }))
+            }
+            placeholder="Search run id, period, tx hash, status..."
+            className="w-full pl-3 pr-8 py-1.5 rounded-md border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+          />
+          {filters.search && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => setFilters((prev) => ({ ...prev, search: "" }))}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowFilters(!showFilters)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
+        >
+          <Filter className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">Filter</span>
+          {activeFilterCount > 0 && (
+            <span className="ml-1 px-1.5 py-0.5 text-xs bg-gray-600 text-white rounded-full">
+              {activeFilterCount}
+            </span>
+          )}
+        </button>
+
+        {activeFilterCount > 0 && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
+            aria-label="Clear all filters"
+          >
+            <X className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">Clear</span>
+          </button>
+        )}
+      </div>
+
+      {showFilters && (
+        <div
+          id="payroll-history-filter-panel"
+          role="region"
+          aria-label="Filter payroll runs"
+          className="mb-4 px-4 sm:px-6 py-4 bg-gray-50 border rounded-lg grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3"
+        >
+          <div>
+            <label htmlFor="filter-status" className="block text-xs font-medium text-gray-600 mb-1">
+              Status
+            </label>
+            <select
+              id="filter-status"
+              value={filters.status}
+              onChange={(e) =>
+                setFilters((f) => ({ ...f, status: e.target.value as StatusFilter }))
+              }
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="all">All statuses</option>
+              <option value="verified">Verified</option>
+              <option value="pending">Pending</option>
+              <option value="failed">Failed</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="filter-outcome" className="block text-xs font-medium text-gray-600 mb-1">
+              Transaction Outcome
+            </label>
+            <select
+              id="filter-outcome"
+              value={filters.outcome}
+              onChange={(e) =>
+                setFilters((f) => ({ ...f, outcome: e.target.value as OutcomeFilter }))
+              }
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="all">All outcomes</option>
+              <option value="complete">Complete</option>
+              <option value="partial">Partial</option>
+              <option value="pending">Pending</option>
+              <option value="failed">Failed</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="filter-date-from" className="block text-xs font-medium text-gray-600 mb-1">
+              From
+            </label>
+            <input
+              id="filter-date-from"
+              type="date"
+              value={filters.dateFrom}
+              onChange={(e) => setFilters((f) => ({ ...f, dateFrom: e.target.value }))}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="filter-date-to" className="block text-xs font-medium text-gray-600 mb-1">
+              To
+            </label>
+            <input
+              id="filter-date-to"
+              type="date"
+              value={filters.dateTo}
+              onChange={(e) => setFilters((f) => ({ ...f, dateTo: e.target.value }))}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+
+      {activeFilterCount > 0 && (
+        <div className="mb-4 px-4 py-2 bg-indigo-50 border border-indigo-100 rounded-lg flex items-center justify-between">
+          <p className="text-xs text-indigo-700">
+            {activeFilterCount} filter{activeFilterCount > 1 ? "s" : ""} active
+            {filteredRuns.length === 0 && " — No runs match the current filters"}
+          </p>
+        </div>
+      )}
+
+      <PayrollCalendar runs={filteredRuns} />
+    </>
+  );
+}
+
+export default PayrollHistory;


### PR DESCRIPTION

## Description

Introduce PayrollHistory, a wrapper around PayrollCalendar that adds search and filter capabilities to the payroll schedule view. Admins can search payroll runs by id, period, tx hash, or status, and combine structured filters for status (All/Verified/Pending/Failed/Cancelled), transaction outcome (All/Complete/Partial/Pending/Failed), and date range (from/to). Active filter count, a clear-all button, and an empty state when no runs match are included. The component replaces the bare PayrollCalendar on /payroll/schedule.

**Fixes:** #209 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Local manual testing (Please describe)
- [x] Unit/Integration Tests
t
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new linting warnings or TypeScript errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #209