### PR TITLE
Add audit export permission tooltip and auditor access expiration banner

### DIFF
--- a/components/features/compliance/ComplianceManager.tsx
+++ b/components/features/compliance/ComplianceManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import {
   Key,
   Plus,
@@ -12,6 +12,7 @@ import {
   Copy,
   Eye,
   EyeOff,
+  Timer,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useViewKeyStore } from "@/stores/viewKeys";
@@ -133,8 +134,95 @@ function ComplianceManager() {
   const inactiveKeys = viewKeys.filter((k) => !k.isActive);
   const pendingRequests = requests.filter((r) => r.status === "pending");
 
+  // ── Auditor Access Expiration Detection ──────────────────────────
+  // Checks active view keys for upcoming or already-expired access.
+  const EXPIRATION_WARNING_DAYS = 30; // warn when key expires within 30 days
+
+  const { expiringKeys, expiredKeys } = useMemo(() => {
+    const now = Date.now();
+    const expiring: ViewKey[] = [];
+    const expired: ViewKey[] = [];
+
+    for (const key of viewKeys) {
+      const expiresAt = new Date(key.expiresAt).getTime();
+      const daysUntilExpiry = Math.floor((expiresAt - now) / (1000 * 60 * 60 * 24));
+
+      if (key.isActive && daysUntilExpiry <= 0) {
+        // Active key that has already passed its expiry date — treat as expired
+        expired.push(key);
+      } else if (key.isActive && daysUntilExpiry <= EXPIRATION_WARNING_DAYS) {
+        expiring.push(key);
+      }
+    }
+
+    return { expiringKeys: expiring, expiredKeys: expired };
+  }, [viewKeys]);
+
   return (
     <section aria-labelledby="compliance-heading" className="space-y-6">
+      {/* ── Auditor Access Expiration Banner ────────────────────────── */}
+      {expiredKeys.length > 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 animate-in fade-in slide-in-from-top-1 duration-300"
+        >
+          <Timer className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-red-800">
+              Auditor Access Expired
+            </p>
+            <p className="text-xs text-red-700 mt-1">
+              {expiredKeys.length} active view key{expiredKeys.length > 1 ? "s have" : " has"} passed their expiration date.
+              {expiredKeys.length > 1 ? " These keys" : " This key"} may no longer function correctly.
+              Please revoke and reissue {expiredKeys.length > 1 ? "them" : "it"} to restore access.
+            </p>
+            <ul className="mt-2 space-y-1">
+              {expiredKeys.map((key) => (
+                <li key={key.id} className="text-xs text-red-700 flex items-center gap-2">
+                  <span className="font-medium">{key.auditorName}</span>
+                  <span className="text-red-500">
+                    (expired {new Date(key.expiresAt).toLocaleDateString()})
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {expiringKeys.length > 0 && expiredKeys.length === 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 animate-in fade-in slide-in-from-top-1 duration-300"
+        >
+          <Timer className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-amber-800">
+              Auditor Access Expiring Soon
+            </p>
+            <p className="text-xs text-amber-700 mt-1">
+              {expiringKeys.length} active view key{expiringKeys.length > 1 ? "s are" : " is"} expiring within {EXPIRATION_WARNING_DAYS} days.
+              Consider renewing {expiringKeys.length > 1 ? "them" : "it"} to avoid interruption.
+            </p>
+            <ul className="mt-2 space-y-1">
+              {expiringKeys.map((key) => {
+                const daysLeft = Math.floor(
+                  (new Date(key.expiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+                );
+                return (
+                  <li key={key.id} className="text-xs text-amber-700 flex items-center gap-2">
+                    <span className="font-medium">{key.auditorName}</span>
+                    <span className="text-amber-600">
+                      ({daysLeft} day{daysLeft !== 1 ? "s" : ""} remaining — expires {new Date(key.expiresAt).toLocaleDateString()})
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center justify-between">
         <div>
           <h2

--- a/components/features/exports/ExportCenter.tsx
+++ b/components/features/exports/ExportCenter.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import type { ComponentType } from "react";
+import { useState, type ComponentType } from "react";
 import {
   AlertTriangle,
   Database,
   Download,
   FileText,
+  HelpCircle,
   Printer,
   ShieldCheck,
 } from "lucide-react";
@@ -27,6 +28,16 @@ interface ExportDefinition {
   actionLabel: string;
   Icon: ComponentType<{ className?: string }>;
   onClick?: () => void;
+  /**
+   * Optional permission info shown as a tooltip.
+   * When set, the action button is wrapped in a container with an info icon
+   * that explains permission constraints based on role, scope, or grant expiry.
+   */
+  permissionTooltip?: {
+    roles: string;
+    detail: string;
+    warning?: string;
+  };
 }
 
 function toCsvRow(values: Array<string | number | null | undefined>) {
@@ -101,6 +112,10 @@ const exportDefinitions: ExportDefinition[] = [
     actionLabel: "Download CSV",
     Icon: Download,
     onClick: exportPayrollHistory,
+    permissionTooltip: {
+      roles: "Admin, Operator, Auditor",
+      detail: "Payroll history is accessible to all dashboard roles. Auditors see aggregated totals only; employee-level detail requires a view key.",
+    },
   },
   {
     title: "Redacted employee directory",
@@ -112,6 +127,11 @@ const exportDefinitions: ExportDefinition[] = [
     actionLabel: "Download CSV",
     Icon: Database,
     onClick: exportEmployeeDirectory,
+    permissionTooltip: {
+      roles: "Admin, Operator",
+      detail: "Employee directory exports are available to admins and operators. Auditors do not have access to employee roster data to maintain privacy boundaries.",
+      warning: "Not available to Auditor role",
+    },
   },
   {
     title: "Audit access requests",
@@ -123,6 +143,11 @@ const exportDefinitions: ExportDefinition[] = [
     actionLabel: "Download CSV",
     Icon: ShieldCheck,
     onClick: exportAuditAccess,
+    permissionTooltip: {
+      roles: "Admin, Auditor",
+      detail: "Audit access exports are limited to admins and auditors. Operators cannot export audit access data to prevent unauthorized compliance data access.",
+      warning: "Not available to Operator role",
+    },
   },
   {
     title: "Cryptographic audit report",
@@ -134,6 +159,10 @@ const exportDefinitions: ExportDefinition[] = [
     actionLabel: "Print report",
     Icon: Printer,
     onClick: () => window.print(),
+    permissionTooltip: {
+      roles: "Admin, Operator, Auditor",
+      detail: "The cryptographic audit report is available to all roles. Report output uses shielded amounts and redacted recipient identifiers to protect privacy.",
+    },
   },
   {
     title: "Treasury funding snapshot",
@@ -144,8 +173,60 @@ const exportDefinitions: ExportDefinition[] = [
     privacy: "Treasury exports avoid employee-level payroll detail by default.",
     actionLabel: "View details",
     Icon: FileText,
+    permissionTooltip: {
+      roles: "Admin",
+      detail: "Treasury funding details are admin-only. Operators and auditors cannot access treasury balance or funding projection data.",
+      warning: "Admin role only",
+    },
   },
 ];
+
+function PermissionTooltip({
+  tooltip,
+}: {
+  tooltip: NonNullable<ExportDefinition["permissionTooltip"]>;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => setIsOpen(false)}
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-indigo-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        aria-label={`Permission info: ${tooltip.detail}`}
+      >
+        <HelpCircle className="w-3.5 h-3.5" />
+        <span>Permissions</span>
+      </button>
+      {isOpen && (
+        <div
+          role="tooltip"
+          className="absolute bottom-full left-0 mb-2 w-72 bg-gray-900 text-white text-xs rounded-lg shadow-xl p-4 z-50 animate-in fade-in slide-in-from-bottom-1 duration-150"
+        >
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 font-semibold text-indigo-300">
+              <ShieldCheck className="w-3.5 h-3.5" />
+              <span>Role Access: {tooltip.roles}</span>
+            </div>
+            <p className="text-gray-300 leading-relaxed">{tooltip.detail}</p>
+            {tooltip.warning && (
+              <div className="flex items-start gap-1.5 pt-2 border-t border-gray-700">
+                <HelpCircle className="w-3 h-3 text-amber-400 shrink-0 mt-0.5" />
+                <p className="text-amber-300">{tooltip.warning}</p>
+              </div>
+            )}
+          </div>
+          <div className="absolute -bottom-1 left-4 w-2 h-2 bg-gray-900 rotate-45" />
+        </div>
+      )}
+    </div>
+  );
+}
 
 function ExportCenter() {
   const verifiedRuns = MOCK_PAYROLL_RUNS.filter((run) => run.status === "verified").length;
@@ -192,7 +273,7 @@ function ExportCenter() {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-2">
-        {exportDefinitions.map(({ title, description, scope, format, fields, privacy, actionLabel, Icon, onClick }) => (
+        {exportDefinitions.map(({ title, description, scope, format, fields, privacy, actionLabel, Icon, onClick, permissionTooltip }) => (
           <article key={title} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-start gap-3">
@@ -225,24 +306,29 @@ function ExportCenter() {
               <p>{privacy}</p>
             </div>
 
-            <div className="mt-4">
-              {onClick ? (
-                <button
-                  type="button"
-                  onClick={onClick}
-                  className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-                >
-                  <Download className="h-4 w-4" aria-hidden="true" />
-                  {actionLabel}
-                </button>
-              ) : (
-                <a
-                  href="/treasury"
-                  className="inline-flex items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-                >
-                  <FileText className="h-4 w-4" aria-hidden="true" />
-                  {actionLabel}
-                </a>
+            <div className="mt-4 flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                {onClick ? (
+                  <button
+                    type="button"
+                    onClick={onClick}
+                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                  >
+                    <Download className="h-4 w-4" aria-hidden="true" />
+                    {actionLabel}
+                  </button>
+                ) : (
+                  <a
+                    href="/treasury"
+                    className="inline-flex items-center gap-2 rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                  >
+                    <FileText className="h-4 w-4" aria-hidden="true" />
+                    {actionLabel}
+                  </a>
+                )}
+              </div>
+              {permissionTooltip && (
+                <PermissionTooltip tooltip={permissionTooltip} />
               )}
             </div>
           </article>


### PR DESCRIPTION
Closes #207
Closes #199

## Changes

### Issue #207 - Add audit export permission tooltip
Added a PermissionTooltip component to the Export Center that explains why exports are enabled or disabled based on role, scope, or grant expiry. Each export card now shows a Permissions button with a hover tooltip containing:
- Role Access indicator showing which roles can access the export
- Detailed explanation of permission constraints
- Warning when a role is excluded from access

### Issue #199 - Add auditor access expiration banner
Added an expiration detection system to the Compliance Manager that:
- Checks active view keys for upcoming or already-expired access
- Shows a red error banner with list of expired keys when access has passed its expiry date
- Shows an amber warning banner with days remaining when keys expire within 30 days
- Automatically updates when view keys change