### PR TITLE
feat: add high-priority dashboard session timeout warning

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { createSessionToken, SESSION_COOKIE_NAME } from '@/lib/auth/session';
+import type { NextRequest } from 'next/server';
+import { createSessionToken, verifySessionToken, SESSION_COOKIE_NAME } from '@/lib/auth/session';
 import { resolveRole } from '@/lib/auth/roles';
 
 export async function POST(request: Request) {
@@ -31,6 +32,39 @@ export async function POST(request: Request) {
   } catch {
     return NextResponse.json(
       { error: 'Failed to create session' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+
+    if (!token) {
+      return NextResponse.json(
+        { error: 'No session' },
+        { status: 401 }
+      );
+    }
+
+    const session = await verifySessionToken(token);
+
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Invalid or expired session' },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({
+      publicKey: session.publicKey,
+      role: session.role,
+      expiresAt: session.expiresAt,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to retrieve session' },
       { status: 500 }
     );
   }

--- a/components/features/dashboard/DashboardHome.tsx
+++ b/components/features/dashboard/DashboardHome.tsx
@@ -10,6 +10,7 @@ import SystemStatus from "@/components/features/dashboard/SystemStatus";
 import QuickActions from "@/components/features/dashboard/QuickActions";
 import OnboardingChecklistPanel from "@/components/features/dashboard/OnboardingChecklistPanel";
 import PinnedAlertsPanel from "@/components/features/dashboard/PinnedAlertsPanel";
+import { SessionTimeoutBanner } from "@/components/features/dashboard/SessionTimeoutBanner";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 function DashboardHome() {
@@ -121,6 +122,9 @@ function DashboardHome() {
         </div>
         <WalletConnect />
       </div>
+      <ErrorBoundary>
+        <SessionTimeoutBanner />
+      </ErrorBoundary>
       <ErrorBoundary>
         <PinnedAlertsPanel alerts={sampleAlerts} tasks={sampleTasks} />
       </ErrorBoundary>

--- a/components/features/dashboard/SessionTimeoutBanner.tsx
+++ b/components/features/dashboard/SessionTimeoutBanner.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession, type SessionState } from "@/hooks/useSession";
+import { AlertTriangle, Clock, LogOut, RefreshCw, ShieldAlert, X } from "lucide-react";
+
+interface SessionTimeoutBannerProps {
+  /** Called when the user chooses to re-authenticate */
+  onReauthenticate?: () => void;
+  /** If true, the banner can be dismissed via a close button (dismissed until next check) */
+  dismissible?: boolean;
+}
+
+/**
+ * Displays a warning banner when the session is nearing expiry or has expired.
+ * Integrates with the useSession hook to monitor session state.
+ * Designed for use on the dashboard and payroll pages.
+ */
+export function SessionTimeoutBanner({
+  onReauthenticate,
+  dismissible = true,
+}: SessionTimeoutBannerProps) {
+  const { sessionState, timeRemaining, formatTimeRemaining, refresh } = useSession();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Re-show if state changes to something more severe
+  useEffect(() => {
+    if (sessionState === "expired" || sessionState === "expiring") {
+      setDismissed(false);
+    }
+  }, [sessionState]);
+
+  if (dismissed || sessionState === "loading" || sessionState === "active") {
+    return null;
+  }
+
+  const handleReauth = () => {
+    if (onReauthenticate) {
+      onReauthenticate();
+    } else {
+      window.location.href = "/login";
+    }
+  };
+
+  if (sessionState === "expired") {
+    return (
+      <div
+        role="alert"
+        className="rounded-lg border border-red-200 bg-red-50 p-4 flex items-start gap-3"
+      >
+        <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-red-600" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <h4 className="text-sm font-semibold text-red-800">Session Expired</h4>
+          <p className="mt-0.5 text-sm text-red-700">
+            Your session has expired. Please log in again to continue using the dashboard.
+            Any in-progress payroll drafts have been preserved.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleReauth}
+              className="inline-flex items-center gap-1.5 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+            >
+              <LogOut className="h-3.5 w-3.5" />
+              Re-authenticate
+            </button>
+            <button
+              type="button"
+              onClick={refresh}
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 border border-red-300"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Check again
+            </button>
+          </div>
+        </div>
+        {dismissible && (
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="shrink-0 text-red-400 hover:text-red-600 transition-colors"
+            aria-label="Dismiss session expired banner"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // sessionState === "expiring"
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-amber-200 bg-amber-50 p-4 flex items-start gap-3"
+    >
+      <Clock className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <h4 className="text-sm font-semibold text-amber-800">
+          Session Expiring Soon
+        </h4>
+        <p className="mt-0.5 text-sm text-amber-700">
+          Your session will expire in approximately{" "}
+          <strong className="font-semibold">{formatTimeRemaining()}</strong>.
+          Please save your work and re-authenticate to avoid disruption.
+          In-progress payroll drafts are automatically preserved.
+        </p>
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleReauth}
+            className="inline-flex items-center gap-1.5 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+          >
+            <LogOut className="h-3.5 w-3.5" />
+            Re-authenticate now
+          </button>
+          <button
+            type="button"
+            onClick={refresh}
+            className="inline-flex items-center gap-1.5 rounded-md bg-white px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-50 border border-amber-300"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Check session
+          </button>
+        </div>
+      </div>
+      {dismissible && (
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="shrink-0 text-amber-400 hover:text-amber-600 transition-colors"
+          aria-label="Dismiss session timeout warning"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/features/payroll/PayrollWizard.tsx
+++ b/components/features/payroll/PayrollWizard.tsx
@@ -26,7 +26,9 @@ import { usePayrollWizardStore } from "@/stores/payrollWizard";
 import { useWalletStore } from "@/stores/walletStore";
 import { EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
 import { IncidentBanner } from "@/components/ui/IncidentBanner";
-import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE } from "@/lib/api/mockData";
+import { SessionTimeoutBanner } from "@/components/features/dashboard/SessionTimeoutBanner";
+import { useSession } from "@/hooks/useSession";
+import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE, MOCK_COMPANIES } from "@/lib/api/mockData";
 import PayrollReceipt from "./PayrollReceipt";
 import type { PayrollWizardStep } from "@/types";
 import { trackEvent, mapErrorToType, bucketEmployeeCount } from "@/lib/telemetry";
@@ -75,8 +77,10 @@ function PayrollWizard() {
     }
   }, [employeeIds.length, hasDraft, submissionStatus]);
 
+  const { sessionState } = useSession();
   const network = useWalletStore((s) => s.network);
   const isWrongNetwork = network !== EXPECTED_NETWORK;
+  const isSessionExpired = sessionState === "expired";
 
   const selectedEmployees = useMemo(
     () => MOCK_EMPLOYEES.filter((e) => employeeIds.includes(e.id)),
@@ -176,6 +180,10 @@ function PayrollWizard() {
           variant="warning"
           message={`Wallet network mismatch: your wallet is connected to ${network}, but this app requires ${EXPECTED_NETWORK}. Switch networks in your wallet to resume payroll actions.`}
         />
+      )}
+
+      {isSessionExpired && (
+        <SessionTimeoutBanner dismissible={false} />
       )}
 
       {showDraftBanner && (
@@ -477,6 +485,8 @@ function ConfirmStep({
 }) {
   const [confirmed, setConfirmed] = useState(false);
   const store = usePayrollWizardStore();
+  const { sessionState } = useSession();
+  const isSessionExpired = sessionState === "expired";
   
   const { isProofNearingExpiration, treasuryBalanceOverride } = store;
   const treasuryBalance = treasuryBalanceOverride !== null && treasuryBalanceOverride !== undefined 
@@ -525,8 +535,13 @@ function ConfirmStep({
       list.push("No employees selected for this payroll run.");
     }
 
+    // 5. Stale session check
+    if (isSessionExpired) {
+      list.push("Your session has expired. Wallet signing cannot proceed with stale authentication. Please re-authenticate before submitting.");
+    }
+
     return list;
-  }, [treasuryBalance, totalAmount, store.proofStatus, selectedEmployees]);
+  }, [treasuryBalance, totalAmount, store.proofStatus, selectedEmployees, isSessionExpired]);
 
   const warnings = useMemo(() => {
     const list: string[] = [];
@@ -819,10 +834,12 @@ function ConfirmStep({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={!confirmed || state === "blocked" || isWrongNetwork}
+          disabled={!confirmed || state === "blocked" || isWrongNetwork || isSessionExpired}
           title={
             isWrongNetwork 
               ? 'Switch to Testnet in Freighter' 
+              : isSessionExpired
+              ? 'Your session has expired. Re-authenticate to continue.'
               : state === "blocked"
               ? 'Resolve blocking errors to proceed'
               : !confirmed

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface SessionInfo {
+  publicKey: string;
+  role: "admin" | "operator" | "auditor";
+  expiresAt: number;
+}
+
+export type SessionState = "loading" | "active" | "expiring" | "expired";
+
+const WARNING_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes before expiry
+const POLL_INTERVAL_MS = 60 * 1000; // Check every 60 seconds
+
+/**
+ * Hook that fetches the current session info from the API and tracks
+ * whether the session is still active, nearing expiry, or already expired.
+ *
+ * - "active":   session is valid with > 10 minutes remaining
+ * - "expiring": session is valid but will expire within 10 minutes
+ * - "expired":  session has expired or no session exists
+ * - "loading":  initial fetch in progress
+ */
+export function useSession() {
+  const [sessionState, setSessionState] = useState<SessionState>("loading");
+  const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
+  const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchSession = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/session", {
+        method: "GET",
+        cache: "no-store",
+      });
+
+      if (!res.ok) {
+        setSessionState("expired");
+        setSessionInfo(null);
+        setTimeRemaining(null);
+        return;
+      }
+
+      const data: SessionInfo = await res.json();
+      const remaining = data.expiresAt - Date.now();
+
+      setSessionInfo(data);
+      setTimeRemaining(remaining);
+
+      if (remaining <= 0) {
+        setSessionState("expired");
+      } else if (remaining <= WARNING_THRESHOLD_MS) {
+        setSessionState("expiring");
+      } else {
+        setSessionState("active");
+      }
+    } catch {
+      setSessionState("expired");
+      setSessionInfo(null);
+      setTimeRemaining(null);
+    }
+  }, []);
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchSession();
+  }, [fetchSession]);
+
+  // Poll periodically to detect expiry
+  useEffect(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+    }
+
+    pollingRef.current = setInterval(() => {
+      fetchSession();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [fetchSession]);
+
+  // Update time remaining every 30 seconds
+  useEffect(() => {
+    if (sessionState === "expired" || sessionState === "loading") return;
+
+    const tick = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev === null || prev <= 0) return 0;
+        const next = prev - 30000;
+        if (next <= 0) {
+          setSessionState("expired");
+          return 0;
+        }
+        if (next <= WARNING_THRESHOLD_MS && sessionState === "active") {
+          setSessionState("expiring");
+        }
+        return next;
+      });
+    }, 30000);
+
+    return () => clearInterval(tick);
+  }, [sessionState]);
+
+  const formatTimeRemaining = useCallback(() => {
+    if (timeRemaining === null || timeRemaining <= 0) return "Expired";
+
+    const totalMinutes = Math.floor(timeRemaining / 60000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m remaining`;
+    }
+    return `${minutes}m remaining`;
+  }, [timeRemaining]);
+
+  return {
+    sessionState,
+    sessionInfo,
+    timeRemaining,
+    formatTimeRemaining,
+    refresh: fetchSession,
+  };
+}


### PR DESCRIPTION
Closes #187

## Summary
- Warn users when their session is about to expire with a prominent dashboard banner
- Block payroll submission in the ConfirmStep when the session has expired
- Provide re-authenticate flow to resume work without losing in-progress drafts
- Add GET /api/auth/session endpoint so client components can check session state

## Testing
- Verified session state transitions (active -> expiring -> expired) via the useSession hook
- SessionTimeoutBanner renders correctly for both expiring and expired states
- ConfirmStep's blocker list includes session expiry and disables the submit button
- Manual verification of the full auth flow: login, session tracking, expiry warning, re-authentication