### PR TITLE
feat(payroll): fix #183 by adding high-priority payroll run lock state UI

### DIFF
--- a/__tests__/smoke/payroll-run-detail.test.tsx
+++ b/__tests__/smoke/payroll-run-detail.test.tsx
@@ -4,16 +4,14 @@ import PayrollRunDetail from "@/components/features/payroll/PayrollRunDetail";
 import { MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
 
 describe("Payroll Run Detail", () => {
-  it("renders scheduled run details with process action", () => {
+  it("renders scheduled submission-locked run without process action", () => {
     const run = MOCK_PAYROLL_RUNS.find((r) => r.id === "tx_003")!;
     render(<PayrollRunDetail run={run} />);
 
-    expect(screen.getByRole("heading", { name: /payroll run/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /payroll run/i })).toBeInTheDocument();
     expect(screen.getByText("Scheduled")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /process payroll/i })).toHaveAttribute(
-      "href",
-      "/payroll/execute",
-    );
+    expect(screen.getByRole("alert", { name: /payroll run locked: submission/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
   });
 
   it("renders completed run without process action", () => {
@@ -29,5 +27,85 @@ describe("Payroll Run Detail", () => {
     render(<PayrollRunDetail run={MOCK_PAYROLL_RUNS[0]} />);
 
     expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+  });
+
+  it("renders lock state banner for submission lock", () => {
+    const run = {
+      id: "lock_sub",
+      companyId: "company_001",
+      timestamp: "2026-07-28T20:00:00Z",
+      createdAt: "2026-07-28T20:00:00Z",
+      totalAmount: 1000,
+      employeeCount: 1,
+      proof: "",
+      status: "pending" as const,
+      employeeIds: ["emp_001"],
+      executedAt: null,
+      transactionHash: null,
+    };
+    render(<PayrollRunDetail run={run} />);
+    expect(screen.getByRole("alert", { name: /payroll run locked: submission/i })).toBeInTheDocument();
+    expect(screen.getByText(/locked for submission/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
+  });
+
+  it("renders lock state banner for confirmation lock", () => {
+    const run = {
+      id: "lock_conf",
+      companyId: "company_001",
+      timestamp: "2026-07-28T20:00:00Z",
+      createdAt: "2026-07-28T20:00:00Z",
+      totalAmount: 1000,
+      employeeCount: 1,
+      proof: "proof-data",
+      status: "pending" as const,
+      employeeIds: ["emp_001"],
+      executedAt: null,
+      transactionHash: "0xhash",
+    };
+    render(<PayrollRunDetail run={run} />);
+    expect(screen.getByRole("alert", { name: /payroll run locked: confirmation/i })).toBeInTheDocument();
+    expect(screen.getByText(/locked for confirmation/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
+  });
+
+  it("renders lock state banner for reconciliation lock", () => {
+    const run = {
+      id: "lock_recon",
+      companyId: "company_001",
+      timestamp: "2026-07-28T20:00:00Z",
+      createdAt: "2026-07-28T20:00:00Z",
+      totalAmount: 1000,
+      employeeCount: 1,
+      proof: "proof-data",
+      status: "verified" as const,
+      employeeIds: ["emp_001"],
+      executedAt: "2026-07-28T20:05:00Z",
+      transactionHash: "0xhash",
+    };
+    render(<PayrollRunDetail run={run} />);
+    expect(screen.getByRole("alert", { name: /payroll run locked: reconciliation/i })).toBeInTheDocument();
+    expect(screen.getByText(/locked for reconciliation/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
+  });
+
+  it("renders lock state banner for cancellation lock", () => {
+    const run = {
+      id: "lock_cancel",
+      companyId: "company_001",
+      timestamp: "2026-07-28T20:00:00Z",
+      createdAt: "2026-07-28T20:00:00Z",
+      totalAmount: 1000,
+      employeeCount: 1,
+      proof: "",
+      status: "cancelled" as const,
+      employeeIds: ["emp_001"],
+      executedAt: null,
+      transactionHash: null,
+    };
+    render(<PayrollRunDetail run={run} />);
+    expect(screen.getByRole("alert", { name: /payroll run locked: cancellation/i })).toBeInTheDocument();
+    expect(screen.getByText(/cancelled and is locked/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /process payroll/i })).not.toBeInTheDocument();
   });
 });

--- a/components/features/payroll/PayrollRunDetail.tsx
+++ b/components/features/payroll/PayrollRunDetail.tsx
@@ -15,6 +15,7 @@ import {
   LinkIcon,
   EyeOff,
   AlertTriangle,
+  Lock,
 } from "lucide-react";
 import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS } from "@/lib/api/mockData";
 import type { PayrollRun } from "@/types/models";
@@ -39,6 +40,22 @@ const STATUS_ICONS: Record<string, LucideIcon> = {
 
 export function findPayrollRun(id: string, runs = MOCK_PAYROLL_RUNS): PayrollRun | undefined {
   return runs.find((run) => run.id === id);
+}
+
+export type LockState = "submission" | "confirmation" | "reconciliation" | "cancellation" | null;
+
+export function getPayrollLockState(run: PayrollRun): LockState {
+  if (run.status === "cancelled") {
+    return "cancellation";
+  }
+  if (run.status === "pending") {
+    const txHash = run.transactionHash ?? run.txHash;
+    return txHash ? "confirmation" : "submission";
+  }
+  if (run.status === "verified") {
+    return "reconciliation";
+  }
+  return null;
 }
 
 interface PayrollRunDetailProps {
@@ -126,6 +143,7 @@ export default function PayrollRunDetail({ run: propRun }: PayrollRunDetailProps
   const runDate = getRunDate(run);
   const StatusIcon = STATUS_ICONS[run.status] ?? Clock;
   const txHash = run.transactionHash ?? run.txHash;
+  const lockState = getPayrollLockState(run);
 
   return (
     <section aria-labelledby="payroll-run-detail-heading" className="space-y-6">
@@ -139,6 +157,31 @@ export default function PayrollRunDetail({ run: propRun }: PayrollRunDetailProps
           Back
         </button>
       </div>
+
+      {lockState && (
+        <div
+          role="alert"
+          aria-label={`Payroll Run Locked: ${lockState}`}
+          className="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-start gap-3"
+        >
+          <Lock className="w-5 h-5 text-amber-600 mt-0.5 shrink-0" aria-hidden="true" />
+          <div>
+            <h3 className="text-sm font-semibold text-amber-800 uppercase tracking-wider text-xs">
+              Payroll Run Locked ({lockState})
+            </h3>
+            <p className="text-sm text-amber-700 mt-1">
+              {lockState === "submission" &&
+                "This payroll run is locked for submission. The transaction details are finalized and cannot be edited while submission is in progress."}
+              {lockState === "confirmation" &&
+                "This payroll run is locked for confirmation. It is currently awaiting on-chain verification on the Stellar network. No edits are allowed."}
+              {lockState === "reconciliation" &&
+                "This payroll run is locked for reconciliation. The transaction is verified on-chain. Edits are disabled to preserve the audit trail."}
+              {lockState === "cancellation" &&
+                "This payroll run has been cancelled and is locked. No further modifications or processing can be performed."}
+            </p>
+          </div>
+        </div>
+      )}
 
       <header className="bg-white rounded-lg shadow-sm p-6">
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
@@ -166,7 +209,7 @@ export default function PayrollRunDetail({ run: propRun }: PayrollRunDetailProps
               </div>
             </div>
           </div>
-          {kind === "scheduled" && (
+          {kind === "scheduled" && !lockState && (
             <Link
               href="/payroll/execute"
               className="inline-flex items-center justify-center px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition-colors shrink-0"


### PR DESCRIPTION
closes #183

# Summary

This PR addresses issue #183. When payroll state transitions occur, users need clear visual boundaries to prevent conflicting edits or triggering duplicate actions. We resolved this by introducing a dynamic lock state classification based on the transaction status and presence of transaction hashes on-chain. When a payroll run enters a locked state (submission, confirmation, reconciliation, or cancellation), a prominent alert banner is displayed containing custom explanations of the lock, and modifications are prevented by hiding edit/process actions.

# Changes Made
* Derived the lock status (`submission`, `confirmation`, `reconciliation`, `cancellation`) dynamically in [`PayrollRunDetail.tsx`](file:///Users/dc/Tochukwu-zkpayroll/zk-payroll-dashboard/components/features/payroll/PayrollRunDetail.tsx) (Fixes #183).
* Integrated a custom Tailwind lock banner containing explicit user explanations and a Lucide `Lock` icon at the top of [`PayrollRunDetail.tsx`](file:///Users/dc/Tochukwu-zkpayroll/zk-payroll-dashboard/components/features/payroll/PayrollRunDetail.tsx) (Fixes #183).
* Conditionally hid the "Process payroll" action link when the run is locked in [`PayrollRunDetail.tsx`](file:///Users/dc/Tochukwu-zkpayroll/zk-payroll-dashboard/components/features/payroll/PayrollRunDetail.tsx) (Fixes #183).
* Implemented comprehensive unit tests validating lock state banner rendering and disabled actions in [`__tests__/smoke/payroll-run-detail.test.tsx`](file:///Users/dc/Tochukwu-zkpayroll/zk-payroll-dashboard/__tests__/smoke/payroll-run-detail.test.tsx) (Fixes #183).

# Testing
Run the vitest suite with:
```bash
npm test
```
All tests under `__tests__/smoke/payroll-run-detail.test.tsx` pass successfully.

