### PR TITLE
feat(compliance): surface auditor view-key expiration banner (#199)

### DIFF
--- a/__tests__/auditor-access-expiration-banner.test.tsx
+++ b/__tests__/auditor-access-expiration-banner.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AuditorAccessExpirationBanner, {
+  AUDITOR_EXPIRATION_SOON_MS,
+} from "@/components/features/compliance/AuditorAccessExpirationBanner";
+import type { ViewKey } from "@/types";
+
+const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+
+function viewKey(overrides: Partial<ViewKey>): ViewKey {
+  return {
+    id: overrides.id ?? `vk_${Math.random().toString(36).slice(2, 10)}`,
+    keyId: overrides.keyId ?? "vk_demo1234abcd",
+    auditorName: overrides.auditorName ?? "Sarah Chen",
+    auditorOrg: overrides.auditorOrg ?? "Deloitte",
+    scope: overrides.scope ?? "full-audit",
+    grantedBy: overrides.grantedBy ?? "Current Admin",
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    expiresAt:
+      overrides.expiresAt ?? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+    isActive: overrides.isActive ?? true,
+    revokedAt: overrides.revokedAt,
+  };
+}
+
+interface RenderArgs {
+  now?: number;
+  warningWindowMs?: number;
+  viewKeys?: ViewKey[];
+}
+
+function renderBanner({
+  now,
+  warningWindowMs,
+  viewKeys,
+}: RenderArgs = {}) {
+  const effectiveNow = now ?? Date.now();
+  const selector = () => viewKeys ?? [];
+  return render(
+    <AuditorAccessExpirationBanner
+      now={effectiveNow}
+      warningWindowMs={warningWindowMs}
+      viewKeysSelector={selector}
+    />,
+  );
+}
+
+describe("AuditorAccessExpirationBanner (#199)", () => {
+  it("renders nothing when there are no view keys", () => {
+    const { container } = renderBanner({ viewKeys: [] });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("renders nothing when all view keys are far from expiring", () => {
+    renderBanner({
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders nothing for revoked/inactive view keys even if past expiresAt", () => {
+    renderBanner({
+      viewKeys: [
+        viewKey({
+          isActive: false,
+          revokedAt: new Date(Date.now() - 1000).toISOString(),
+          expiresAt: new Date(Date.now() - 1000).toISOString(),
+        }),
+      ],
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders an error banner when an active key has already expired", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(1_700_000_000_000 - 1000).toISOString(),
+        }),
+      ],
+    });
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/expired/i);
+    expect(banner).toHaveTextContent("Sarah Chen");
+    expect(banner).toHaveTextContent("Deloitte");
+  });
+
+  it("renders a warning banner when an active key is within the 7-day window", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(1_700_000_000_000 + 3 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/expires in 3 days/i);
+  });
+
+  it("aggregates counts when several keys are expiring soon", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          auditorName: "Alice",
+          expiresAt: new Date(1_700_000_000_000 + 2 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        viewKey({
+          auditorName: "Bob",
+          expiresAt: new Date(1_700_000_000_000 + 6 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/2 auditor view keys/i);
+    // The soonest (sorted ascending) is surfaced by name in the message.
+    expect(banner).toHaveTextContent("Alice");
+    expect(banner).toHaveTextContent("1 more");
+  });
+
+  it("prefers the error variant when at least one key is already expired", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          auditorName: "Bob",
+          expiresAt: new Date(1_700_000_000_000 + 1 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        viewKey({
+          auditorName: "Alice",
+          expiresAt: new Date(1_700_000_000_000 - 1000).toISOString(),
+        }),
+      ],
+    });
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/expired/i);
+  });
+
+  it("honours a custom warning window", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      warningWindowMs: 2 * 24 * 60 * 60 * 1000,
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(1_700_000_000_000 + 5 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+      ],
+    });
+    // Outside the custom 2-day window → should not show anything.
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("is dismissible when rendered", () => {
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(1_700_000_000_000 - 1000).toISOString(),
+        }),
+      ],
+    });
+    expect(screen.getByRole("button", { name: /dismiss/i })).toBeInTheDocument();
+  });
+
+  it("exposes AUDITOR_EXPIRATION_SOON_MS as 7 days", () => {
+    expect(AUDITOR_EXPIRATION_SOON_MS).toBe(SEVEN_DAYS);
+  });
+
+  it("ignores keys with invalid expiresAt timestamps", () => {
+    // Should not throw, should not render a banner.
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          expiresAt: "not-a-real-date",
+        }),
+      ],
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("dismissing the error banner hides it from the page", async () => {
+    const user = userEvent.setup();
+    renderBanner({
+      now: 1_700_000_000_000,
+      viewKeys: [
+        viewKey({
+          expiresAt: new Date(1_700_000_000_000 - 1000).toISOString(),
+        }),
+      ],
+    });
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/components/features/compliance/AuditorAccessExpirationBanner.tsx
+++ b/components/features/compliance/AuditorAccessExpirationBanner.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo } from "react";
+import { useViewKeyStore } from "@/stores/viewKeys";
+import { IncidentBanner } from "@/components/ui/IncidentBanner";
+import type { ViewKey } from "@/types";
+
+export const AUDITOR_EXPIRATION_SOON_MS = 7 * 24 * 60 * 60 * 1000;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+function daysUntil(iso: string, now: number): number {
+  return Math.max(1, Math.ceil((new Date(iso).getTime() - now) / (24 * 60 * 60 * 1000)));
+}
+
+function aggregateMessage(
+  keys: ViewKey[],
+  now: number,
+  expired: boolean
+): string {
+  const count = keys.length;
+  const sample = keys[0]!;
+  const sampleDays = expired ? 0 : daysUntil(sample.expiresAt, now);
+  const moreCount = count - 1;
+
+  if (expired) {
+    if (count === 1) {
+      return `Auditor access for ${sample.auditorName} (${sample.auditorOrg}) expired on ${formatDate(sample.expiresAt)}. Revoke or renew to restore compliance.`;
+    }
+    if (moreCount === 1) {
+      return `${count} auditor view keys have expired. The most recent is ${sample.auditorName} (${sample.auditorOrg}) \u2014 expired on ${formatDate(sample.expiresAt)}. Revoke or renew to restore compliance. 1 more.`;
+    }
+    return `${count} auditor view keys have expired. The most recent is ${sample.auditorName} (${sample.auditorOrg}) \u2014 expired on ${formatDate(sample.expiresAt)}. Revoke or renew to restore compliance. ${moreCount} more.`;
+  }
+
+  if (count === 1) {
+    return `Auditor access for ${sample.auditorName} (${sample.auditorOrg}) expires in ${sampleDays} day${sampleDays === 1 ? "" : "s"} (${formatDate(sample.expiresAt)}). Renew before it lapses.`;
+  }
+  if (moreCount === 1) {
+    return `${count} auditor view keys expire within ${AUDITOR_EXPIRATION_SOON_MS / (24 * 60 * 60 * 1000)} days. The soonest is ${sample.auditorName} (${sample.auditorOrg}) \u2014 ${sampleDays} day${sampleDays === 1 ? "" : "s"} remaining. 1 more.`;
+  }
+  return `${count} auditor view keys expire within ${AUDITOR_EXPIRATION_SOON_MS / (24 * 60 * 60 * 1000)} days. The soonest is ${sample.auditorName} (${sample.auditorOrg}) \u2014 ${sampleDays} day${sampleDays === 1 ? "" : "s"} remaining. ${moreCount} more.`;
+}
+
+export interface AuditorAccessExpirationBannerProps {
+  /** Override "now" used for expiration calculations. Defaults to Date.now(). */
+  now?: number;
+  /** Override threshold (ms). Defaults to 7 days. */
+  warningWindowMs?: number;
+  /** Custom store hook — useful for tests. */
+  viewKeysSelector?: (state: { viewKeys: ViewKey[] }) => ViewKey[];
+}
+
+/**
+ * Surface auditor view keys that are about to expire (or have already
+ * expired) so admin/auditor workflows don't fail silently (#199).
+ *
+ * The banner aggregates per-key state from the persisted view key store and
+ * renders a global, dismissible `IncidentBanner`:
+ *
+ *  - One or more keys already expired  → `variant="error"`
+ *  - One or more active keys expiring within the warning window (~7 days)
+ *                                       → `variant="warning"`
+ *  - Otherwise                          → renders nothing
+ *
+ * Pure derived state — the banner intentionally never mutates the store.
+ * The dismissible state is owned by the underlying `IncidentBanner` itself,
+ * so a refresh re-surfaces expired access if it is still present.
+ */
+export default function AuditorAccessExpirationBanner({
+  now,
+  warningWindowMs = AUDITOR_EXPIRATION_SOON_MS,
+  viewKeysSelector = (state) => state.viewKeys,
+}: AuditorAccessExpirationBannerProps = {}) {
+  const viewKeys = useViewKeyStore(viewKeysSelector);
+
+  const classifications = useMemo(() => {
+    const effectiveNow = now ?? Date.now();
+    const expired: ViewKey[] = [];
+    const soonExpiring: ViewKey[] = [];
+
+    for (const key of viewKeys) {
+      if (!key.isActive) continue;
+      const expiry = new Date(key.expiresAt).getTime();
+      if (Number.isNaN(expiry)) continue;
+      if (expiry <= effectiveNow) {
+        expired.push(key);
+      } else if (expiry - effectiveNow <= warningWindowMs) {
+        soonExpiring.push(key);
+      }
+    }
+
+    expired.sort(
+      (a, b) => new Date(a.expiresAt).getTime() - new Date(b.expiresAt).getTime(),
+    );
+    soonExpiring.sort(
+      (a, b) => new Date(a.expiresAt).getTime() - new Date(b.expiresAt).getTime(),
+    );
+
+    return { expired, soonExpiring, effectiveNow };
+  }, [viewKeys, now, warningWindowMs]);
+
+  const { expired, soonExpiring, effectiveNow } = classifications;
+
+  if (expired.length === 0 && soonExpiring.length === 0) return null;
+
+  if (expired.length > 0) {
+    return (
+      <IncidentBanner
+        variant="error"
+        message={aggregateMessage(expired, effectiveNow, true)}
+        dismissible
+      />
+    );
+  }
+
+  return (
+    <IncidentBanner
+      variant="warning"
+      message={aggregateMessage(soonExpiring, effectiveNow, false)}
+      dismissible
+    />
+  );
+}

--- a/components/layout/DashboardLayout.tsx
+++ b/components/layout/DashboardLayout.tsx
@@ -7,6 +7,7 @@ import Sidebar from "./Sidebar";
 import EnvironmentBanner from "./EnvironmentBanner";
 import CommandPalette from "./CommandPalette";
 import PrintAuditReport from "../features/transactions/PrintAuditReport";
+import AuditorAccessExpirationBanner from "../features/compliance/AuditorAccessExpirationBanner";
 
 function DashboardLayout({ children }: { children: React.ReactNode }) {
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -40,6 +41,9 @@ function DashboardLayout({ children }: { children: React.ReactNode }) {
         <Sidebar />
         <div className="flex-1 flex flex-col overflow-hidden">
           <EnvironmentBanner />
+          <div className="px-6 pt-4 print:hidden" data-testid="auditor-expiration-banner-wrapper">
+            <AuditorAccessExpirationBanner />
+          </div>
           <Header />
           <main
             id="main-content"


### PR DESCRIPTION
Closes #199

## Summary
Adds a global, dismissible banner that surfaces auditor view keys that are about to expire (within 7 days) or have already expired, so audit workflows no longer fail silently.

## Why
Per the issue: audit workflows fail quietly if access expiration is hidden from admins and auditors. The dashboard already tracks active view keys via useViewKeyStore, but nothing currently pushes that state to the user.

## What
- New components/features/compliance/AuditorAccessExpirationBanner.tsx: derives expired vs. soon-expiring keys from the view-key store and renders the existing IncidentBanner (error variant for expired, warning variant for soon-expiring). Aggregates counts and surfaces the soonest auditor by name. Honors a configurable warning window (defaults to 7 days). Pure derived state, never mutates the store.
- components/layout/DashboardLayout.tsx: mounts the banner once, just above <Header />, so it is visible across admin/auditor pages.
- New __tests__/auditor-access-expiration-banner.test.tsx: 12 tests covering empty/inactive/far-future keys, expired keys, soon-expiring keys, count aggregation, error-preferred-over-warning ordering, custom window, invalid timestamps, dismissibility, and the 7-day constant.

## Notes
- The dismissible state is local to the underlying IncidentBanner. A fresh load re-surfaces expired access while it is still present, which is the desired behaviour for compliance.
- The banner does not expose grant IDs or on-chain identifiers, only auditor names/organisations/expiry dates that are already visible elsewhere in the Compliance tab.