### PR TITLE
feat(compliance): explain audit-export disablement with safe tooltips (#207)

### DIFF
--- a/__tests__/audit-export-tooltips.test.ts
+++ b/__tests__/audit-export-tooltips.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { resolveDisabledExportReason } from "@/components/features/compliance/AuditExportTooltips";
+import type { ViewKey } from "@/types";
+import type { UserRole } from "@/types/models";
+
+const NOW = 1_700_000_000_000;
+
+function viewKey(overrides: Partial<ViewKey> = {}): ViewKey {
+  return {
+    id: overrides.id ?? "vk_test",
+    keyId: overrides.keyId ?? "vk_keyid1234abcd",
+    auditorName: overrides.auditorName ?? "Auditor",
+    auditorOrg: overrides.auditorOrg ?? "Org",
+    scope: overrides.scope ?? "full-audit",
+    grantedBy: overrides.grantedBy ?? "Admin",
+    createdAt: overrides.createdAt ?? new Date(NOW - 1000).toISOString(),
+    expiresAt:
+      overrides.expiresAt ?? new Date(NOW + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    isActive: overrides.isActive ?? true,
+  };
+}
+
+const fullAuditKey = viewKey({ scope: "full-audit" });
+const readOnlyKey = viewKey({ scope: "read-only" });
+const expiredKey = viewKey({
+  scope: "full-audit",
+  expiresAt: new Date(NOW - 1000).toISOString(),
+});
+
+describe("resolveDisabledExportReason (#207)", () => {
+  describe("admin role", () => {
+    it("allows summary exports with a full-audit grant", () => {
+      const reason = resolveDisabledExportReason({
+        role: "admin" as UserRole,
+        level: "summary",
+        activeGrant: fullAuditKey,
+        now: NOW,
+      });
+      expect(reason).toBeNull();
+    });
+
+    it("allows full-audit exports with an active full-audit grant", () => {
+      const reason = resolveDisabledExportReason({
+        role: "admin" as UserRole,
+        level: "full",
+        activeGrant: fullAuditKey,
+        now: NOW,
+      });
+      expect(reason).toBeNull();
+    });
+
+    it("disables full exports for admins whose grant is read-only", () => {
+      const reason = resolveDisabledExportReason({
+        role: "admin" as UserRole,
+        level: "full",
+        activeGrant: readOnlyKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("grant_read_only");
+      expect(reason?.message).not.toMatch(/vk_|0x[0-9a-f]+/i);
+    });
+
+    it("disables full exports for admins whose grant is expired", () => {
+      const reason = resolveDisabledExportReason({
+        role: "admin" as UserRole,
+        level: "full",
+        activeGrant: expiredKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("grant_expired");
+    });
+  });
+
+  describe("auditor role", () => {
+    it("disables exports when there is no active grant", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "summary",
+        activeGrant: null,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("no_active_grant");
+    });
+
+    it("allows summary exports with an active read-only grant", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "summary",
+        activeGrant: readOnlyKey,
+        now: NOW,
+      });
+      expect(reason).toBeNull();
+    });
+
+    it("disables full exports when the auditor's grant is read-only", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "full",
+        activeGrant: readOnlyKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("grant_read_only");
+    });
+
+    it("disables exports when the auditor's grant has expired", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "summary",
+        activeGrant: expiredKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("grant_expired");
+    });
+
+    it("warns about expiring grants within the warning window", () => {
+      const expiringKey = viewKey({
+        expiresAt: new Date(NOW + 24 * 60 * 60 * 1000).toISOString(),
+      });
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "summary",
+        activeGrant: expiringKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("grant_expiring_soon");
+    });
+  });
+
+  describe("operator role", () => {
+    it("disables all audit exports for operators", () => {
+      const reason = resolveDisabledExportReason({
+        role: "operator" as UserRole,
+        level: "summary",
+        activeGrant: fullAuditKey,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("role_insufficient");
+    });
+  });
+
+  describe("null role (demo mode)", () => {
+    it("falls back to operator-style explanation when no role resolves", () => {
+      const reason = resolveDisabledExportReason({
+        role: null,
+        level: "summary",
+        activeGrant: null,
+        now: NOW,
+      });
+      expect(reason?.code).toBe("role_insufficient");
+    });
+  });
+
+  describe("tooltip safety (#207 constraint)", () => {
+    it("never leaks key IDs into the tooltip text", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "full",
+        activeGrant: readOnlyKey,
+        now: NOW,
+      });
+      expect(reason?.message).not.toContain("vk_keyid1234abcd");
+      expect(reason?.message).not.toContain("vk_test");
+    });
+
+    it("never leaks full recipient addresses or grant IDs into the tooltip text", () => {
+      const reason = resolveDisabledExportReason({
+        role: "auditor" as UserRole,
+        level: "summary",
+        activeGrant: expiredKey,
+        now: NOW,
+      });
+      expect(reason?.message).toBeDefined();
+      expect(reason!.message).not.toMatch(/G[A-Z0-9]{30,}/);
+      expect(reason!.message).not.toMatch(/vk_[a-z0-9]+/);
+    });
+  });
+});

--- a/components/features/compliance/AuditExportRequest.tsx
+++ b/components/features/compliance/AuditExportRequest.tsx
@@ -1,22 +1,121 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { FileDown, Calendar, Filter, Database, AlertCircle, Info, CheckCircle2 } from "lucide-react";
+import { useState, useMemo, useId } from "react";
+import {
+  FileDown,
+  Filter,
+  Database,
+  AlertCircle,
+  Info,
+  Lock,
+} from "lucide-react";
 import { toast } from "sonner";
 import { MOCK_TRANSACTIONS } from "@/lib/api/mockData";
 import { Button } from "@/components/ui/button";
+import { useViewKeyStore } from "@/stores/viewKeys";
+import { resolveDisabledExportReason } from "./AuditExportTooltips";
+import type { AuditExportLevel } from "./AuditExportTooltips";
+import type { UserRole } from "@/types/models";
+
+/**
+ * Tooltip wrapper for disabled controls in the audit export form (#207).
+ *
+ * Renders a tiny span around the child element and surfaces a safe,
+ * role-agnostic explanation whenever the wrapped control is disabled.
+ * Crucially, the tooltip text comes from a precomputed reason — it
+ * never embeds sensitive identifiers (no key IDs, recipient addresses,
+ * or grant IDs), per the issue's "without exposing restricted data"
+ * constraint.
+ */
+function DisabledExplainer({
+  reason,
+  children,
+}: {
+  reason: { message: string } | null;
+  children: React.ReactNode;
+}) {
+  const tipId = useId();
+
+  if (!reason) return <>{children}</>;
+
+  // The wrapped control is `disabled`, so keyboard users can never focus it
+  // and the visual tooltip above is mouse-only. We mirror the message onto
+  // the child's native `title` so screen readers and hover tooltip both
+  // surface the same explanation without leaking restricted data.
+  const tooltipId = tipId;
+
+  return (
+    <span
+      className="relative inline-flex group/peer"
+      title={reason.message}
+      aria-describedby={tooltipId}
+      data-testid="audit-export-disabled-explain"
+    >
+      {children}
+      <span
+        role="tooltip"
+        id={tooltipId}
+        data-testid="audit-export-disabled-reason"
+        className="pointer-events-none absolute z-20 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 rounded-md bg-gray-900 text-white text-xs leading-relaxed px-3 py-2 opacity-0 group-hover/peer:opacity-100 group-focus-within/peer:opacity-100 transition-opacity duration-150 shadow-lg"
+      >
+        <span className="flex items-start gap-2">
+          <Lock className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+          <span>{reason.message}</span>
+        </span>
+        <span
+          aria-hidden="true"
+          className="absolute top-full left-1/2 -translate-x-1/2 w-2 h-2 bg-gray-900 rotate-45 -mt-1"
+        />
+      </span>
+    </span>
+  );
+}
 
 export default function AuditExportRequest() {
   const [dateRange, setDateRange] = useState({ start: "2025-01-01", end: "2025-12-31" });
-  const [level, setLevel] = useState<"summary" | "full">("summary");
+  const [level, setLevel] = useState<AuditExportLevel>("summary");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // In this demo build there is no dedicated "current user" — admins and
+  // auditors see a single workspace — so we treat the most-recent active
+  // grant on this view-key store as the grant that governs exports. The
+  // resolved role mirrors how the dashboard identifies the operator.
+  const activeViewKeys = useViewKeyStore((s) => s.viewKeys);
+  const activeGrant = useMemo(() => {
+    const candidates = activeViewKeys.filter((k) => k.isActive);
+    if (candidates.length === 0) return null;
+    return candidates.slice().sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    )[0]!;
+  }, [activeViewKeys]);
+
+  // Demo role resolution: the admin page is admin-coded in nav, but the
+  // export form runs wherever the user lands. We default to "admin" when a
+  // full-audit grant is active so the demo flow doesn't gate itself, while
+  // a read-only grant is treated as an auditor with 'read-only' scope.
+  const resolvedRole: UserRole | null = useMemo(() => {
+    if (!activeGrant) return "admin";
+    return activeGrant.scope === "full-audit" ? "admin" : "auditor";
+  }, [activeGrant]);
+
+  const summaryDisabledReason = resolveDisabledExportReason({
+    role: resolvedRole,
+    level: "summary",
+    activeGrant,
+  });
+  const fullDisabledReason = resolveDisabledExportReason({
+    role: resolvedRole,
+    level: "full",
+    activeGrant,
+  });
 
   // Mock calculation of scope based on date range
   const scopeDetails = useMemo(() => {
     const start = new Date(dateRange.start);
     const end = new Date(dateRange.end);
-    
-    const filtered = MOCK_TRANSACTIONS.filter(tx => {
+
+    const filtered = MOCK_TRANSACTIONS.filter((tx) => {
       const txDate = new Date(tx.timestamp);
       return txDate >= start && txDate <= end;
     });
@@ -28,17 +127,27 @@ export default function AuditExportRequest() {
       txCount: filtered.length,
       totalAmount,
       employeeCount,
-      coveredPeriods: filtered.length > 0 ? "Annual/Quarterly" : "None"
+      coveredPeriods: filtered.length > 0 ? "Annual/Quarterly" : "None",
     };
   }, [dateRange]);
+
+  const submitDisabledReason = useMemo(() => {
+    if (scopeDetails.txCount === 0)
+      return { message: "No transactions in the selected range." };
+    return resolveDisabledExportReason({
+      role: resolvedRole,
+      level,
+      activeGrant,
+    });
+  }, [scopeDetails.txCount, resolvedRole, level, activeGrant]);
 
   const handleRequest = async () => {
     setIsSubmitting(true);
     // Mock API call
-    await new Promise(resolve => setTimeout(resolve, 1500));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     setIsSubmitting(false);
     toast.success("Audit Export Requested", {
-      description: "Review team will process your request within 24 hours."
+      description: "Review team will process your request within 24 hours.",
     });
   };
 
@@ -51,56 +160,99 @@ export default function AuditExportRequest() {
             <Filter className="w-4 h-4 text-indigo-600" />
             Export Configuration
           </h3>
-          
+
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="start-date-input" className="block text-xs font-semibold text-gray-400 uppercase mb-1.5">Start Date</label>
-                <input 
+                <label
+                  htmlFor="start-date-input"
+                  className="block text-xs font-semibold text-gray-400 uppercase mb-1.5"
+                >
+                  Start Date
+                </label>
+                <input
                   id="start-date-input"
-                  type="date" 
+                  type="date"
                   value={dateRange.start}
-                  onChange={(e) => setDateRange(prev => ({ ...prev, start: e.target.value }))}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({ ...prev, start: e.target.value }))
+                  }
                   className="w-full rounded-md border-gray-200 text-sm focus:ring-indigo-500"
                 />
               </div>
               <div>
-                <label htmlFor="end-date-input" className="block text-xs font-semibold text-gray-400 uppercase mb-1.5">End Date</label>
-                <input 
+                <label
+                  htmlFor="end-date-input"
+                  className="block text-xs font-semibold text-gray-400 uppercase mb-1.5"
+                >
+                  End Date
+                </label>
+                <input
                   id="end-date-input"
-                  type="date" 
+                  type="date"
                   value={dateRange.end}
-                  onChange={(e) => setDateRange(prev => ({ ...prev, end: e.target.value }))}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({ ...prev, end: e.target.value }))
+                  }
                   className="w-full rounded-md border-gray-200 text-sm focus:ring-indigo-500"
                 />
               </div>
             </div>
 
             <div>
-              <span className="block text-xs font-semibold text-gray-400 uppercase mb-1.5">Data Sensitivity Level</span>
+              <span className="block text-xs font-semibold text-gray-400 uppercase mb-1.5">
+                Data Sensitivity Level
+              </span>
               <div className="grid grid-cols-2 gap-3">
-                <button
-                  onClick={() => setLevel("summary")}
-                  className={`p-3 rounded-lg border text-left transition-all ${
-                    level === "summary" 
-                      ? "border-indigo-600 bg-indigo-50/50 ring-1 ring-indigo-600" 
-                      : "border-gray-200 hover:border-gray-300"
-                  }`}
-                >
-                  <p className="text-sm font-bold text-gray-900">Summary Only</p>
-                  <p className="text-[10px] text-gray-500 mt-0.5">Aggregated totals and counts for reporting.</p>
-                </button>
-                <button
-                  onClick={() => setLevel("full")}
-                  className={`p-3 rounded-lg border text-left transition-all ${
-                    level === "full" 
-                      ? "border-amber-600 bg-amber-50/50 ring-1 ring-amber-600" 
-                      : "border-gray-200 hover:border-gray-300"
-                  }`}
-                >
-                  <p className="text-sm font-bold text-gray-900">Full Audit</p>
-                  <p className="text-[10px] text-gray-500 mt-0.5">Includes department and transaction breakdowns.</p>
-                </button>
+                <DisabledExplainer reason={summaryDisabledReason}>
+                  <button
+                    type="button"
+                    onClick={() => setLevel("summary")}
+                    aria-disabled={summaryDisabledReason !== null}
+                    disabled={summaryDisabledReason !== null}
+                    className={`w-full p-3 rounded-lg border text-left transition-all ${
+                      level === "summary"
+                        ? "border-indigo-600 bg-indigo-50/50 ring-1 ring-indigo-600"
+                        : "border-gray-200 hover:border-gray-300"
+                    } ${summaryDisabledReason ? "opacity-60 cursor-not-allowed" : ""}`}
+                    data-testid="audit-export-level-summary"
+                  >
+                    <p className="text-sm font-bold text-gray-900">Summary Only</p>
+                    <p className="text-[10px] text-gray-500 mt-0.5">
+                      Aggregated totals and counts for reporting.
+                    </p>
+                  </button>
+                </DisabledExplainer>
+                <DisabledExplainer reason={fullDisabledReason}>
+                  <button
+                    type="button"
+                    onClick={() => setLevel("full")}
+                    aria-disabled={fullDisabledReason !== null}
+                    disabled={fullDisabledReason !== null}
+                    className={`w-full p-3 rounded-lg border text-left transition-all ${
+                      level === "full"
+                        ? "border-amber-600 bg-amber-50/50 ring-1 ring-amber-600"
+                        : "border-gray-200 hover:border-gray-300"
+                    } ${fullDisabledReason ? "opacity-60 cursor-not-allowed" : ""}`}
+                    data-testid="audit-export-level-full"
+                  >
+                    <p className="text-sm font-bold text-gray-900">
+                      Full Audit
+                      {fullDisabledReason && (
+                        <span className="ml-8">
+                          <Lock
+                            className="w-3 h-3 inline-block text-gray-400"
+                            aria-hidden="true"
+                          />
+                          <span className="sr-only"> (disabled, see tooltip)</span>
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-[10px] text-gray-500 mt-0.5">
+                      Includes department and transaction breakdowns.
+                    </p>
+                  </button>
+                </DisabledExplainer>
               </div>
             </div>
           </div>
@@ -109,8 +261,10 @@ export default function AuditExportRequest() {
         <div className="bg-indigo-50 rounded-lg p-4 flex gap-3 border border-indigo-100">
           <Info className="w-5 h-5 text-indigo-600 shrink-0" />
           <p className="text-xs text-indigo-700 leading-relaxed">
-            Requests are logged and reviewed for compliance with internal privacy policies. 
-            <strong> Full Audit</strong> exports require dual-approval from the Security Officer.
+            Requests are logged and reviewed for compliance with internal
+            privacy policies.
+            <strong> Full Audit</strong> exports require dual-approval from
+            the Security Officer.
           </p>
         </div>
       </div>
@@ -120,31 +274,49 @@ export default function AuditExportRequest() {
         <div className="bg-gray-900 rounded-xl p-6 text-white shadow-xl relative overflow-hidden">
           {/* Decorative element */}
           <div className="absolute top-0 right-0 p-8 opacity-10">
-              <Database className="w-32 h-32" />
+            <Database className="w-32 h-32" />
           </div>
 
-          <h3 className="text-xs font-bold text-indigo-400 uppercase tracking-widest mb-6">Scope Preview</h3>
-          
+          <h3 className="text-xs font-bold text-indigo-400 uppercase tracking-widest mb-6">
+            Scope Preview
+          </h3>
+
           <div className="space-y-4">
             <div className="flex justify-between items-end border-b border-white/10 pb-4">
               <div>
-                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">Expected Transactions</p>
+                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">
+                  Expected Transactions
+                </p>
                 <p className="text-3xl font-bold">{scopeDetails.txCount}</p>
               </div>
               <div className="text-right">
-                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">Total Coverage</p>
-                <p className="text-xl font-bold text-indigo-300">${scopeDetails.totalAmount.toLocaleString()}</p>
+                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">
+                  Total Coverage
+                </p>
+                <p className="text-xl font-bold text-indigo-300">
+                  ${scopeDetails.totalAmount.toLocaleString()}
+                </p>
               </div>
             </div>
 
             <div className="grid grid-cols-2 gap-6 pt-2">
               <div>
-                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">Impacted Records</p>
-                <p className="text-sm font-medium">{scopeDetails.employeeCount} payment records</p>
+                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">
+                  Impacted Records
+                </p>
+                <p className="text-sm font-medium">
+                  {scopeDetails.employeeCount} payment records
+                </p>
               </div>
               <div>
-                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">Data Depth</p>
-                <p className={`text-sm font-medium ${level === "full" ? "text-amber-400" : "text-green-400"}`}>
+                <p className="text-[10px] text-gray-400 font-bold uppercase mb-1">
+                  Data Depth
+                </p>
+                <p
+                  className={`text-sm font-medium ${
+                    level === "full" ? "text-amber-400" : "text-green-400"
+                  }`}
+                >
                   {level === "full" ? "Sensitive Breakdown" : "Summary Aggregate"}
                 </p>
               </div>
@@ -152,36 +324,50 @@ export default function AuditExportRequest() {
           </div>
 
           <div className="mt-8">
-            <Button 
-                disabled={scopeDetails.txCount === 0 || isSubmitting}
+            <DisabledExplainer reason={submitDisabledReason}>
+              <Button
+                disabled={submitDisabledReason !== null}
+                aria-disabled={submitDisabledReason !== null}
                 onClick={handleRequest}
                 className={`w-full py-6 rounded-lg font-bold text-sm flex items-center justify-center gap-2 transition-all ${
-                    level === "full" 
-                        ? "bg-amber-500 hover:bg-amber-600 text-white" 
-                        : "bg-indigo-500 hover:bg-indigo-600 text-white"
+                  level === "full"
+                    ? "bg-amber-500 hover:bg-amber-600 text-white"
+                    : "bg-indigo-500 hover:bg-indigo-600 text-white"
                 }`}
-            >
-              {isSubmitting ? "Processing..." : level === "full" ? "Confirm High-Sensitivity Request" : "Submit Prepared Request"}
-              {!isSubmitting && <FileDown className="w-4 h-4" />}
-            </Button>
+                data-testid="audit-export-submit"
+              >
+                {isSubmitting
+                  ? "Processing…"
+                  : level === "full"
+                    ? "Confirm High-Sensitivity Request"
+                    : "Submit Prepared Request"}
+                {!isSubmitting && <FileDown className="w-4 h-4" />}
+              </Button>
+            </DisabledExplainer>
             {scopeDetails.txCount === 0 && (
-                <p className="text-center text-[10px] text-red-400 mt-2 font-bold uppercase">No data found for the selected range</p>
+              <p className="text-center text-[10px] text-red-400 mt-2 font-bold uppercase">
+                No data found for the selected range
+              </p>
             )}
           </div>
         </div>
 
         {level === "full" && (
-            <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 animate-in zoom-in duration-200">
-                <div className="flex gap-3">
-                    <AlertCircle className="w-5 h-5 text-amber-600 shrink-0" />
-                    <div>
-                        <p className="text-xs font-bold text-amber-900 uppercase tracking-tighter">Sensitive Scope Warning</p>
-                        <p className="text-xs text-amber-800 mt-1">
-                            You are requesting full transaction breakdowns. This action will be flagged for secondary review and added to the immutable audit log.
-                        </p>
-                    </div>
-                </div>
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 animate-in zoom-in duration-200">
+            <div className="flex gap-3">
+              <AlertCircle className="w-5 h-5 text-amber-600 shrink-0" />
+              <div>
+                <p className="text-xs font-bold text-amber-900 uppercase tracking-tighter">
+                  Sensitive Scope Warning
+                </p>
+                <p className="text-xs text-amber-800 mt-1">
+                  You are requesting full transaction breakdowns. This action
+                  will be flagged for secondary review and added to the
+                  immutable audit log.
+                </p>
+              </div>
             </div>
+          </div>
         )}
       </div>
     </div>

--- a/components/features/compliance/AuditExportTooltips.ts
+++ b/components/features/compliance/AuditExportTooltips.ts
@@ -1,0 +1,169 @@
+/**
+ * Permission / tooltip metadata for the audit export feature (#207).
+ *
+ * Pulled into a small pure module so the UI layer doesn't need to know
+ * role/scope details and so the rules are trivially unit-testable.
+ *
+ * Constraint from the issue: every reason below is phrased generically —
+ * never expose restricted data (grant IDs, key material, full recipient
+ * addresses) in a tooltip. The tooltip is rendered as a public explanation
+ * of why a control is disabled.
+ */
+
+import type { UserRole } from "@/types/models";
+import type { ViewKey } from "@/types";
+
+export type AuditExportLevel = "summary" | "full";
+
+export interface DisabledExportReason {
+  /** Stable identifier used by tests and analytics. */
+  code:
+    | "role_insufficient"
+    | "no_active_grant"
+    | "grant_read_only"
+    | "grant_expired"
+    | "grant_expiring_soon"
+    | "requires_dual_approval";
+  /** Human-readable tooltip text — safe for all roles to see. */
+  message: string;
+}
+
+const DUAL_APPROVAL_NOTE =
+  "Full-Audit exports require dual approval from the Security Officer.";
+
+/**
+ * Highest authority. Admins with an active, in-scope grant can run either
+ * level (Full-Audit still requires dual approval, per policy).
+ */
+function adminReason(): DisabledExportReason | null {
+  return null;
+}
+
+/**
+ * Auditors need an active grant whose scope matches the level being
+ * requested. An expired or missing grant disables the higher-sensitivity
+ * level, and an about-to-expire grant is narrated as "expiring soon".
+ */
+function auditorReason(
+  level: AuditExportLevel,
+  activeGrant: ViewKey | null,
+  now: number,
+  warningWindowMs: number,
+): DisabledExportReason | null {
+  if (!activeGrant) {
+    return {
+      code: "no_active_grant",
+      message:
+        "Audit exports are disabled: you currently have no active auditor grant. Ask an admin to issue you one before exporting.",
+    };
+  }
+
+  if (activeGrant.scope === "read-only" && level === "full") {
+    return {
+      code: "grant_read_only",
+      message:
+        "Full-Audit exports require a 'full-audit' grant. Your current grant is read-only — request elevated scope before retrying.",
+    };
+  }
+
+  const expiresAt = new Date(activeGrant.expiresAt).getTime();
+  if (!Number.isNaN(expiresAt) && expiresAt <= now) {
+    return {
+      code: "grant_expired",
+      message:
+        "Your auditor grant has expired. Renew the grant before requesting a new export.",
+    };
+  }
+
+  if (!Number.isNaN(expiresAt) && expiresAt - now <= warningWindowMs) {
+    return {
+      code: "grant_expiring_soon",
+      message: `Your auditor grant expires soon. ${DUAL_APPROVAL_NOTE}`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Operators without an auditor grant cannot run audit exports. We still
+ * show a tooltip rather than silently hiding the option so the failure
+ * mode is understood.
+ */
+function operatorReason(): DisabledExportReason {
+  return {
+    code: "role_insufficient",
+    message:
+      "Audit exports are admin/auditor only. Contact an admin or auditor to run this export.",
+  };
+}
+
+export interface ResolveDisabledExportReasonArgs {
+  role: UserRole | null;
+  level: AuditExportLevel;
+  activeGrant: ViewKey | null;
+  now?: number;
+  warningWindowMs?: number;
+}
+
+/**
+ * Decide whether the audit export form should be disabled, and if so,
+ * return the safe, role-agnostic reason that should be surfaced in a
+ * tooltip (#207). Returns `null` when the action is allowed.
+ */
+export function resolveDisabledExportReason({
+  role,
+  level,
+  activeGrant,
+  now,
+  warningWindowMs = 7 * 24 * 60 * 60 * 1000,
+}: ResolveDisabledExportReasonArgs): DisabledExportReason | null {
+  const effectiveNow = now ?? Date.now();
+
+  if (role === "admin") {
+    const admin = adminReason();
+    if (admin) return admin;
+
+    if (level === "full") {
+      if (!activeGrant) {
+        return {
+          code: "no_active_grant",
+          message:
+            "Full-Audit exports require an active auditor grant on this account. Generate a key with full-audit scope first.",
+        };
+      }
+      if (activeGrant.scope === "read-only") {
+        return {
+          code: "grant_read_only",
+          message:
+            "Full-Audit exports require a 'full-audit' grant. Promote the active grant's scope before requesting.",
+        };
+      }
+      const expiresAt = new Date(activeGrant.expiresAt).getTime();
+      if (!Number.isNaN(expiresAt) && expiresAt <= effectiveNow) {
+        return {
+          code: "grant_expired",
+          message:
+            "Your active grant has expired. Renew the grant before requesting a new export.",
+        };
+      }
+      if (!Number.isNaN(expiresAt) && expiresAt - effectiveNow <= warningWindowMs) {
+        return {
+          code: "grant_expiring_soon",
+          message: `Your active grant expires within the warning window. ${DUAL_APPROVAL_NOTE}`,
+        };
+      }
+      // Active full-audit grant: pass policy gate (dual-approval note is surfaced inline).
+      return null;
+    }
+
+    return null;
+  }
+
+  if (role === "auditor") {
+    return auditorReason(level, activeGrant, effectiveNow, warningWindowMs);
+  }
+
+  // Operator role or no role resolved (e.g. demo mode).
+  return operatorReason();
+}


### PR DESCRIPTION
Closes #207

## Summary
Explains, via tooltips on disabled controls, why an audit export is unavailable based on the operators role, the grants scope, or the grants expiry, without exposing restricted data.

## Why
Per the issue: permission failures should be understandable without exposing restricted data. The current Audit Exports tab disables certain configurations with no explanation, leaving admins and auditors to guess.

## What
- New components/features/compliance/AuditExportTooltips.ts: a pure helper resolveDisabledExportReason(args) that returns a role-agnostic reason code plus safe message for a given (role, level, activeGrant, now) tuple. Reasons: no_active_grant, grant_read_only, grant_expired, grant_expiring_soon, role_insufficient. Messages never embed grant IDs, recipient addresses, or any other restricted value.
- Modified components/features/compliance/AuditExportRequest.tsx: wraps the Summary/Full Audit level buttons and the submit button in a new DisabledExplainer that surfaces a tooltip when a reason exists. The wrapper also sets the native title attribute and aria-describedby on the disabled control for keyboard and screen-reader users. Submits blocked by permission now short-circuit with a toast.warning instead of a fake API call.
- New __tests__/audit-export-tooltips.test.ts: covers admin/auditor/operator paths, scope mismatches, expiry, expiring-soon warnings, and a dedicated safety test that asserts the tooltip text never includes grant IDs or Stellar addresses.