### PR TITLE
fix(payroll): repair PayrollWizard typecheck and lint failures

### DIFF
--- a/components/features/payroll/PayrollWizard.tsx
+++ b/components/features/payroll/PayrollWizard.tsx
@@ -26,7 +26,7 @@ import { usePayrollWizardStore } from "@/stores/payrollWizard";
 import { useWalletStore } from "@/stores/walletStore";
 import { EXPECTED_NETWORK } from "@/components/providers/StellarProvider";
 import { IncidentBanner } from "@/components/ui/IncidentBanner";
-import { MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE } from "@/lib/api/mockData";
+import { MOCK_COMPANIES, MOCK_EMPLOYEES, MOCK_PAYROLL_RUNS, MOCK_TREASURY_BALANCE } from "@/lib/api/mockData";
 import PayrollReceipt from "./PayrollReceipt";
 import type { PayrollWizardStep } from "@/types";
 import { trackEvent, mapErrorToType, bucketEmployeeCount } from "@/lib/telemetry";
@@ -786,7 +786,11 @@ function ConfirmStep({
 
       {/* Explicit Confirmation Checkbox */}
       <div className="bg-indigo-50/50 border border-indigo-150 rounded-lg p-4">
-        <label className="flex items-start gap-3 cursor-pointer select-none">
+        <label
+          htmlFor="confirm-checkbox"
+          aria-labelledby="confirm-checkbox-title"
+          className="flex items-start gap-3 cursor-pointer select-none"
+        >
           <input
             id="confirm-checkbox"
             type="checkbox"
@@ -796,7 +800,10 @@ function ConfirmStep({
             className="w-4 h-4 text-indigo-600 border-gray-300 rounded mt-0.5 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           />
           <div>
-            <span className="text-sm font-medium text-gray-900">
+            <span
+              id="confirm-checkbox-title"
+              className="text-sm font-medium text-gray-900"
+            >
               Confirm Payroll Execution Summary
             </span>
             <p className="text-xs text-gray-600 mt-0.5">


### PR DESCRIPTION
## Summary
Fixes two pre-existing CI failures in components/features/payroll/PayrollWizard.tsx so the dashboard CI is green on main:

1. **Typecheck error (line 495):** `Cannot find name 'MOCK_COMPANIES'`. `MOCK_COMPANIES` was referenced inside `ConfirmStep` but never imported. Added it to the existing mockData import.

2. **Lint error (line 789):** `A form label must have accessible text` from `jsx-a11y/label-has-associated-control`. The original `<label>` wrapped the `<input id="confirm-checkbox">` but the rules accessible-text heuristic did not pick up the title/description text nested inside `<div>/<span>/<p>`. Added an explicit `htmlFor="confirm-checkbox"` for the control association and `aria-labelledby="confirm-checkbox-title"` pointing to the title `<span>` (now given a matching id) for the accessible name. This preserves the descriptive `<p>` acknowledgement copy for screen readers while satisfying the lint check.

## Verification
- `npm run typecheck` passes cleanly.
- `npm run lint` reports ✔ No ESLint warnings or errors.
- Visual layout is unchanged (still `flex items-start gap-3` with checkbox on the left and the title + acknowledgement on the right).
- The `<p>` acknowledgement text remains in the DOM and is still announced by screen readers; `aria-labelledby` only sets the labels accessible name, it does not hide descendant content.

## Why these specific fixes
- `htmlFor` makes the label/input association explicit instead of relying on the implicit wrapping pattern, which is more robust for assistive tech.
- `aria-labelledby` (rather than `aria-label`) avoids duplicating the visible label text and preserves a single source of truth between the visual and the accessible name.