### PR TITLE
feat(payroll): wire SDK reconciliation diff into run detail page

### DIFF
--- a/__tests__/components/ReconciliationDiffPanel.test.tsx
+++ b/__tests__/components/ReconciliationDiffPanel.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, within, fireEvent, act } from "@testing-library/react";
+import ReconciliationDiffPanel from "@/components/features/payroll/ReconciliationDiffPanel";
+import type { Employee, PayrollRun } from "@/types/models";
+
+const NOW = 1_700_000_000_000;
+
+function run(overrides: Partial<PayrollRun> = {}): PayrollRun {
+  return {
+    id: overrides.id ?? "tx_test",
+    companyId: overrides.companyId ?? "company_001",
+    timestamp: overrides.timestamp ?? "2025-02-28T09:00:00Z",
+    createdAt: overrides.createdAt ?? "2025-02-28T09:00:00Z",
+    totalAmount: overrides.totalAmount ?? 10000,
+    employeeCount: overrides.employeeCount ?? 2,
+    proof: overrides.proof ?? "0xproof",
+    status: overrides.status ?? "verified",
+    txHash: overrides.txHash ?? "0xabc",
+    isArchived: overrides.isArchived ?? false,
+    employeeIds: overrides.employeeIds ?? ["emp_a", "emp_b"],
+    executedAt: overrides.executedAt ?? "2025-02-28T09:00:00Z",
+    transactionHash: overrides.transactionHash ?? "0xabc",
+  };
+}
+
+function employee(overrides: Partial<Employee> = {}): Employee {
+  return {
+    id: overrides.id ?? "emp_test",
+    address: overrides.address ?? "GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+    name: overrides.name ?? "Test Employee",
+    salary: overrides.salary ?? 5000,
+    salaryCommitment: overrides.salaryCommitment ?? "0xcommit",
+    isActive: overrides.isActive ?? true,
+    status: overrides.status ?? "active",
+    onboardingStatus: overrides.onboardingStatus ?? "completed",
+    startDate: overrides.startDate ?? "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("ReconciliationDiffPanel", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the panel and a copy button", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee({ address: "GAAAA11111111111111111111111111111111111111111" })]}
+        now={NOW}
+      />,
+    );
+
+    expect(screen.getByTestId("reconciliation-diff-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("reconciliation-diff-copy")).toBeInTheDocument();
+  });
+
+  it("shows a 'fully reconciled' summary for verified runs", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run({ status: "verified" })}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    expect(screen.getByText(/fully reconciled/i)).toBeInTheDocument();
+    expect(screen.getByText(/All payments reconcile cleanly/i)).toBeInTheDocument();
+  });
+
+  it("shows a 'needs attention' summary for failed runs", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run({ status: "failed" })}
+        employees={[
+          employee({ id: "a", address: "GAAAA11111111111111111111111111111111111111111" }),
+          employee({ id: "b", address: "GBBBB22222222222222222222222222222222222222222" }),
+        ]}
+        now={NOW}
+      />,
+    );
+
+    expect(screen.getByText(/Differences detected/i)).toBeInTheDocument();
+  });
+
+  it("renders the formatted diff text inside the <pre> block", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    const pre = screen.getByTestId("reconciliation-diff-text");
+    expect(pre.textContent).toMatch(/reconciliation:/);
+    expect(pre.textContent?.length ?? 0).toBeGreaterThan(10);
+  });
+
+  it("writes the diff text to the clipboard when the copy button is clicked", async () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("reconciliation-diff-copy"));
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const arg = writeText.mock.calls[0]?.[0] as string;
+    expect(arg).toMatch(/^reconciliation:/);
+  });
+
+  it("falls back to a textarea + execCommand when clipboard.writeText is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    // execCommand is legacy; we deliberately stub it for the fallback path.
+    document.execCommand = execCommand;
+
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("reconciliation-diff-copy"));
+    await Promise.resolve();
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("toggles the 'Copied' label after clicking and resets after a delay", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    const button = screen.getByTestId("reconciliation-diff-copy");
+    fireEvent.click(button);
+    await act(async () => {
+      // Let the await navigator.clipboard.writeText() promise resolve.
+      await Promise.resolve();
+    });
+    expect(within(button).getByText("Copied")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(within(button).getByText("Copy")).toBeInTheDocument();
+  });
+
+  it("renders as a section with the operator-view header", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    const panel = screen.getByTestId("reconciliation-diff-panel");
+    expect(panel.tagName.toLowerCase()).toBe("section");
+    expect(panel).toHaveAttribute("aria-label", "Operator reconciliation diff");
+  });
+
+  it("fires an error toast when navigator.clipboard.writeText rejects", async () => {
+    writeText.mockRejectedValueOnce(new Error("clipboard denied"));
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+    // Should not throw, even when the clipboard rejects.
+    fireEvent.click(screen.getByTestId("reconciliation-diff-copy"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The button should still show "Copy" (not "Copied") because the
+    // handler caught the rejection before flipping state.
+    const button = screen.getByTestId("reconciliation-diff-copy");
+    expect(within(button).getByText("Copy")).toBeInTheDocument();
+  });
+
+  // Regression guard: the privacy warning copy should be in the DOM.
+  it("renders the privacy notice about unredacted stroops", () => {
+    render(
+      <ReconciliationDiffPanel
+        run={run()}
+        employees={[employee()]}
+        now={NOW}
+      />,
+    );
+
+    expect(
+      screen.getByText(/contains unredacted stroops/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/reconciliation/format.test.ts
+++ b/__tests__/lib/reconciliation/format.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { formatReconciliationDiff } from "@/lib/reconciliation/format";
+import type { ReconciliationDiffResult } from "@/lib/reconciliation/types";
+
+function result(overrides: Partial<ReconciliationDiffResult> = {}): ReconciliationDiffResult {
+  return {
+    entries: [],
+    counts: {
+      match: 0,
+      missing: 0,
+      failed_mismatch: 0,
+      amount_mismatch: 0,
+      still_pending: 0,
+      unexpected: 0,
+    },
+    isFullyReconciled: true,
+    generatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("formatReconciliationDiff (vendored SDK helper)", () => {
+  it("emits a single header line for an empty run", () => {
+    const out = formatReconciliationDiff(result());
+    expect(out.startsWith("reconciliation: fully reconciled")).toBe(true);
+    expect(out).toContain("no entries");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("reports 'needs attention' when isFullyReconciled is false", () => {
+    const out = formatReconciliationDiff(
+      result({
+        isFullyReconciled: false,
+        counts: { match: 0, missing: 1, failed_mismatch: 0, amount_mismatch: 0, still_pending: 0, unexpected: 0 },
+      }),
+    );
+    expect(out.startsWith("reconciliation: needs attention")).toBe(true);
+    expect(out).toContain("1 missing");
+  });
+
+  it("sorts actionable categories before routine ones", () => {
+    const r = result({
+      isFullyReconciled: false,
+      entries: [
+        {
+          recipient: "GALICE",
+          category: "match",
+          reason: "ok",
+        },
+        {
+          recipient: "GBOB",
+          category: "failed_mismatch",
+          reason: "client says success, chain says failed",
+        },
+        {
+          recipient: "GCHARLIE",
+          category: "missing",
+          reason: "no on-chain record",
+        },
+      ],
+      counts: { match: 1, missing: 1, failed_mismatch: 1, amount_mismatch: 0, still_pending: 0, unexpected: 0 },
+    });
+    const out = formatReconciliationDiff(r);
+    const lines = out.split("\n");
+    const bobIdx = lines.findIndex((l) => l.includes("GBOB"));
+    const charlieIdx = lines.findIndex((l) => l.includes("GCHARLIE"));
+    const aliceIdx = lines.findIndex((l) => l.includes("GALICE"));
+    expect(bobIdx).toBeLessThan(charlieIdx);
+    expect(charlieIdx).toBeLessThan(aliceIdx);
+  });
+
+  it("honours custom indent and newline options", () => {
+    const r = result({
+      entries: [{ recipient: "GALICE", category: "match", reason: "ok" }],
+    });
+    const out = formatReconciliationDiff(r, {
+      indent: ">>",
+      newline: "|",
+    });
+    expect(out).toContain(">>GALICE");
+    expect(out).toContain("|");
+  });
+
+  it("is pure: same input => same output", () => {
+    const r = result({
+      entries: [{ recipient: "GALICE", category: "match", reason: "ok" }],
+    });
+    expect(formatReconciliationDiff(r)).toBe(formatReconciliationDiff(r));
+  });
+
+  it("buckets match + still_pending under 'routine' in the count summary", () => {
+    const out = formatReconciliationDiff(
+      result({
+        counts: {
+          match: 3,
+          missing: 0,
+          failed_mismatch: 0,
+          amount_mismatch: 0,
+          still_pending: 2,
+          unexpected: 0,
+        },
+        entries: [],
+      }),
+    );
+    expect(out).toContain("5 routine");
+  });
+});

--- a/__tests__/lib/reconciliation/mockObserved.test.ts
+++ b/__tests__/lib/reconciliation/mockObserved.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  synthesizeReconciliation,
+  buildReconciliationDiff,
+} from "@/lib/reconciliation/mockObserved";
+import { generateReconciliationDiff } from "@/lib/reconciliation/ReconciliationDiffGenerator";
+import type { Employee, PayrollRun } from "@/types/models";
+
+const NOW = 1_700_000_000_000;
+
+function employee(overrides: Partial<Employee> = {}): Employee {
+  return {
+    id: overrides.id ?? "emp_test",
+    address: overrides.address ?? "GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+    name: overrides.name ?? "Test Employee",
+    salary: overrides.salary ?? 5000,
+    salaryCommitment: overrides.salaryCommitment ?? "0xcommit",
+    isActive: overrides.isActive ?? true,
+    status: overrides.status ?? "active",
+    onboardingStatus: overrides.onboardingStatus ?? "completed",
+    startDate: overrides.startDate ?? "2024-01-01T00:00:00Z",
+  };
+}
+
+function run(overrides: Partial<PayrollRun> = {}): PayrollRun {
+  return {
+    id: overrides.id ?? "tx_test",
+    companyId: overrides.companyId ?? "company_001",
+    timestamp: overrides.timestamp ?? "2025-02-28T09:00:00Z",
+    createdAt: overrides.createdAt ?? "2025-02-28T09:00:00Z",
+    totalAmount: overrides.totalAmount ?? 10000,
+    employeeCount: overrides.employeeCount ?? 2,
+    proof: overrides.proof ?? "0xproof",
+    status: overrides.status ?? "verified",
+    txHash: overrides.txHash ?? "0xabc",
+    isArchived: overrides.isArchived ?? false,
+    employeeIds: overrides.employeeIds ?? ["emp_a", "emp_b"],
+    executedAt: overrides.executedAt ?? "2025-02-28T09:00:00Z",
+    transactionHash: overrides.transactionHash ?? "0xabc",
+  };
+}
+
+describe("synthesizeReconciliation", () => {
+  it("converts dollar salaries to bigint stroops", () => {
+    const { expected } = synthesizeReconciliation(
+      run(),
+      [employee({ salary: 5000 })],
+      NOW,
+    );
+    expect(expected.results[0]!.amount).toBe(BigInt(50_000_000_000));
+  });
+
+  it("classifies verified runs as success / observed-confirmed → all match", () => {
+    const { expected, observed } = synthesizeReconciliation(
+      run({ status: "verified" }),
+      [employee({ id: "a", address: "GAAAA" }), employee({ id: "b", address: "GBBBB" })],
+      NOW,
+    );
+    const result = generateReconciliationDiff(expected, observed);
+    expect(result.counts.match).toBe(2);
+    expect(result.isFullyReconciled).toBe(true);
+  });
+
+  it("classifies failed runs: first employee confirmed (mismatch), rest not_found (missing)", () => {
+    const a = employee({ id: "a", address: "GAAAA" });
+    const b = employee({ id: "b", address: "GBBBB" });
+    const c = employee({ id: "c", address: "GCCCC" });
+    const diff = buildReconciliationDiff(run({ status: "failed" }), [a, b, c], NOW);
+    expect(diff.counts.failed_mismatch).toBe(1);
+    expect(diff.counts.missing).toBe(2);
+    expect(diff.isFullyReconciled).toBe(false);
+  });
+
+  it("classifies pending runs as pending / not_found → all still_pending", () => {
+    const a = employee({ id: "a", address: "GAAAA" });
+    const b = employee({ id: "b", address: "GBBBB" });
+    const diff = buildReconciliationDiff(run({ status: "pending" }), [a, b], NOW);
+    expect(diff.counts.still_pending).toBe(2);
+    expect(diff.counts.match).toBe(0);
+    // pending runs aren't actionable yet, so isFullyReconciled stays true.
+    expect(diff.isFullyReconciled).toBe(true);
+  });
+
+  it("classifies cancelled runs as still_pending (synthesis maps cancelled → pending)", () => {
+    const a = employee({ id: "a", address: "GAAAA" });
+    const diff = buildReconciliationDiff(run({ status: "cancelled" }), [a], NOW);
+    expect(diff.counts.still_pending).toBe(1);
+  });
+
+  it("preserves the run's transactionHash on expected outcomes", () => {
+    const { expected } = synthesizeReconciliation(
+      run({ transactionHash: "0xspecial" }),
+      [employee()],
+      NOW,
+    );
+    expect(expected.results[0]!.txHash).toBe("0xspecial");
+  });
+});

--- a/components/features/payroll/PayrollRunDetail.tsx
+++ b/components/features/payroll/PayrollRunDetail.tsx
@@ -25,6 +25,7 @@ import {
   getRunDate,
   RUN_KIND_STYLES,
 } from "@/lib/payroll/scheduleUtils";
+import ReconciliationDiffPanel from "@/components/features/payroll/ReconciliationDiffPanel";
 
 
 
@@ -347,6 +348,8 @@ export default function PayrollRunDetail({ run: propRun }: PayrollRunDetailProps
           {employeesInRun.length} employee{employeesInRun.length !== 1 ? "s" : ""} in this run
         </div>
       </div>
+
+      <ReconciliationDiffPanel run={run} employees={employeesInRun} />
 
       <div className="flex flex-wrap gap-3">
         <Link

--- a/components/features/payroll/ReconciliationDiffPanel.tsx
+++ b/components/features/payroll/ReconciliationDiffPanel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState, useCallback } from "react";
+import { Clipboard, ClipboardCheck, Terminal, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
+import { formatReconciliationDiff } from "@/lib/reconciliation/format";
+import { buildReconciliationDiff } from "@/lib/reconciliation/mockObserved";
+import type { Employee, PayrollRun } from "@/types/models";
+
+export interface ReconciliationDiffPanelProps {
+  /** The payroll run whose expected outcomes should be reconciled. */
+  run: PayrollRun;
+  /** Employees that participated in the run. */
+  employees: Employee[];
+  /** Optional clock for deterministic synthesis in tests. */
+  now?: number;
+}
+
+/**
+ * Operator-facing reconciliation diff card.
+ *
+ * Pulls the SDK-shaped diff between expected outcomes and observed
+ * on-chain state (synthesized for the dashboard demo), renders the
+ * grep-friendly string, and offers a one-click copy affordance for
+ * pasting into Slack or a log file.
+ *
+ * The card is visually distinguished as an "operator view" with an
+ * inline privacy warning so casual viewers don't accidentally read
+ * the per-recipient stroop amounts during normal dashboard browsing.
+ */
+export default function ReconciliationDiffPanel({
+  run,
+  employees,
+  now,
+}: ReconciliationDiffPanelProps) {
+  const [copied, setCopied] = useState(false);
+
+  const { diffText, isFullyReconciled } = useMemo(() => {
+    const result = buildReconciliationDiff(run, employees, now);
+    return {
+      diffText: formatReconciliationDiff(result),
+      isFullyReconciled: result.isFullyReconciled,
+    };
+  }, [run, employees, now]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(diffText);
+      } else {
+        // Fallback for browsers without the async Clipboard API.
+        const ta = document.createElement("textarea");
+        ta.value = diffText;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "absolute";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      }
+      setCopied(true);
+      toast.success("Reconciliation diff copied", {
+        description: "Ready to paste into a log file or chat thread.",
+      });
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      toast.error("Could not copy diff", {
+        description: err instanceof Error ? err.message : "Clipboard unavailable.",
+      });
+    }
+  }, [diffText]);
+
+  const summary = isFullyReconciled
+    ? "All payments reconcile cleanly"
+    : "Differences detected — review the diff below";
+
+  return (
+    <section
+      data-testid="reconciliation-diff-panel"
+      aria-label="Operator reconciliation diff"
+      className="bg-white rounded-lg shadow-sm overflow-hidden"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3 px-4 sm:px-6 py-4 border-b bg-gray-50">
+        <span className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+          <Terminal className="w-4 h-4 text-indigo-600" aria-hidden="true" />
+          Operator view (contains unredacted stroops)
+        </span>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full border ${
+              isFullyReconciled
+                ? "bg-green-50 text-green-700 border-green-200"
+                : "bg-amber-50 text-amber-700 border-amber-200"
+            }`}
+          >
+            {summary}
+          </span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={copied ? "Copied" : "Copy reconciliation diff"}
+            data-testid="reconciliation-diff-copy"
+            className="inline-flex items-center gap-1 rounded-md bg-slate-800 hover:bg-slate-700 text-slate-100 text-xs font-medium px-2 py-1 transition-colors border border-slate-700"
+          >
+            {copied ? (
+              <>
+                <ClipboardCheck className="w-3.5 h-3.5" aria-hidden="true" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Clipboard className="w-3.5 h-3.5" aria-hidden="true" />
+                Copy
+              </>
+            )}
+          </button>
+        </div>
+      </header>
+      <div className="p-4 sm:p-6 space-y-4">
+        <div className="flex items-start gap-3 text-xs text-gray-600">
+          <ShieldAlert
+            className="w-4 h-4 mt-0.5 text-amber-500 shrink-0"
+            aria-hidden="true"
+          />
+          <p>
+            This view is intended for operators triaging a run. It surfaces
+            per-recipient reconciliation status and per-stroop amounts
+            that are not shown elsewhere on this page. Do not share outside
+            the operations team.
+          </p>
+        </div>
+
+        <div className="relative bg-slate-900 rounded-md overflow-hidden">
+          <pre
+            data-testid="reconciliation-diff-text"
+            className="text-slate-100 text-xs font-mono leading-relaxed p-4 overflow-x-auto whitespace-pre-wrap break-words"
+          >
+            {diffText}
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/reconciliation/ReconciliationDiffGenerator.ts
+++ b/lib/reconciliation/ReconciliationDiffGenerator.ts
@@ -1,0 +1,182 @@
+/**
+ * Vendored copy of `@zk-payroll/core`'s
+ * `reconciliation/ReconciliationDiffGenerator.ts` — see
+ * `lib/reconciliation/format.ts` for the rationale. Once the SDK packaging
+ * is fixed, this file can be removed and the dashboard can import the
+ * real helper from `@zk-payroll/core`.
+ */
+import type {
+  ObservedPaymentState,
+  ReconciliationDiffCategory,
+  ReconciliationDiffEntry,
+  ReconciliationDiffResult,
+} from "./types";
+
+const CATEGORIES: ReconciliationDiffCategory[] = [
+  "match",
+  "missing",
+  "failed_mismatch",
+  "amount_mismatch",
+  "still_pending",
+  "unexpected",
+];
+
+/** Key used to match an expected outcome to an observed state. */
+function matchKey(recipient: string, asset: string): string {
+  return `${recipient}:${asset}`;
+}
+
+function entry(
+  recipient: string,
+  category: ReconciliationDiffCategory,
+  reason: string,
+  expected?: ReconciliationDiffEntry["expected"],
+  observed?: ObservedPaymentState,
+): ReconciliationDiffEntry {
+  return { recipient, category, reason, expected, observed };
+}
+
+/**
+ * Compare one expected outcome against its (possibly absent) observed
+ * counterpart and classify the result.
+ */
+function diffOne(
+  outcome: {
+    recipient: string;
+    amount: bigint;
+    asset: string;
+    status: "success" | "failure" | "pending";
+    txHash?: string;
+  },
+  observed: ObservedPaymentState | undefined,
+): ReconciliationDiffEntry {
+  const expected = {
+    amount: outcome.amount,
+    asset: outcome.asset,
+    status: outcome.status,
+    txHash: outcome.txHash,
+  };
+
+  if (outcome.status === "pending") {
+    return entry(
+      outcome.recipient,
+      "still_pending",
+      "Expected outcome has not reached a terminal state yet; nothing to reconcile.",
+      expected,
+      observed,
+    );
+  }
+
+  if (!observed || observed.onChainStatus === "not_found") {
+    return entry(
+      outcome.recipient,
+      "missing",
+      outcome.status === "success"
+        ? "Client recorded this payment as successful, but no matching on-chain record was found."
+        : "Client recorded this payment as failed, and no on-chain record was found (consistent, but unverifiable).",
+      expected,
+      observed,
+    );
+  }
+
+  const expectedSucceeded = outcome.status === "success";
+  const observedSucceeded = observed.onChainStatus === "confirmed";
+
+  if (expectedSucceeded !== observedSucceeded) {
+    return entry(
+      outcome.recipient,
+      "failed_mismatch",
+      expectedSucceeded
+        ? "Client recorded this payment as successful, but the chain shows it failed."
+        : "Client recorded this payment as failed, but the chain shows it actually confirmed -- possible duplicate submission or a stale client-side result.",
+      expected,
+      observed,
+    );
+  }
+
+  if (
+    observedSucceeded &&
+    observed.amount !== undefined &&
+    observed.amount !== outcome.amount
+  ) {
+    return entry(
+      outcome.recipient,
+      "amount_mismatch",
+      `Expected amount ${outcome.amount.toString()} stroops does not match observed amount ${observed.amount.toString()} stroops.`,
+      expected,
+      observed,
+    );
+  }
+
+  return entry(
+    outcome.recipient,
+    "match",
+    "Expected and observed outcomes agree.",
+    expected,
+    observed,
+  );
+}
+
+/**
+ * Generate a reconciliation diff between a payroll run's expected results
+ * and independently observed on-chain/contract state.
+ */
+export function generateReconciliationDiff(
+  expected: {
+    results: Array<{
+      recipient: string;
+      amount: bigint;
+      asset: string;
+      status: "success" | "failure" | "pending";
+      txHash?: string;
+    }>;
+  },
+  observed: ObservedPaymentState[],
+): ReconciliationDiffResult {
+  const observedByKey = new Map<string, ObservedPaymentState>();
+  for (const o of observed) {
+    if (o.asset === undefined) continue;
+    const key = matchKey(o.recipient, o.asset);
+    const existing = observedByKey.get(key);
+    if (!existing || o.observedAt > existing.observedAt) {
+      observedByKey.set(key, o);
+    }
+  }
+
+  const matchedObservedKeys = new Set<string>();
+  const entries: ReconciliationDiffEntry[] = expected.results.map((outcome) => {
+    const key = matchKey(outcome.recipient, outcome.asset);
+    const observedMatch = observedByKey.get(key);
+    if (observedMatch) matchedObservedKeys.add(key);
+    return diffOne(outcome, observedMatch);
+  });
+
+  for (const o of observed) {
+    const key = o.asset !== undefined ? matchKey(o.recipient, o.asset) : undefined;
+    const wasMatched = key !== undefined && matchedObservedKeys.has(key);
+    if (wasMatched) continue;
+    if (o.onChainStatus === "not_found") continue;
+
+    entries.push(
+      entry(
+        o.recipient,
+        "unexpected",
+        "On-chain record found for this recipient with no corresponding expected outcome in this run.",
+        undefined,
+        o,
+      ),
+    );
+  }
+
+  const counts = Object.fromEntries(CATEGORIES.map((c) => [c, 0])) as Record<
+    ReconciliationDiffCategory,
+    number
+  >;
+  for (const e of entries) counts[e.category]++;
+
+  const isFullyReconciled = entries.every(
+    (e) => e.category === "match" || e.category === "still_pending",
+  );
+
+  return { entries, counts, isFullyReconciled, generatedAt: Date.now() };
+}

--- a/lib/reconciliation/format.ts
+++ b/lib/reconciliation/format.ts
@@ -1,0 +1,86 @@
+/**
+ * Vendored copy of `@zk-payroll/core`'s `formatReconciliationDiff` helper
+ * (added in zk-payroll-sdk PR #243). The dashboard cannot currently consume
+ * `@zk-payroll/core` as an npm dependency because the SDK's published
+ * `main`/`types` paths do not match its `tsc` output (rootDir inferred
+ * from the include list, so `dist/` is laid out as `dist/src/...`).
+ *
+ * Once the SDK packaging is fixed, this file can be removed and replaced
+ * with `import { formatReconciliationDiff } from "@zk-payroll/core"`. The
+ * function is pure with no transitive runtime dependencies.
+ */
+import type {
+  ReconciliationDiffCategory,
+  ReconciliationDiffResult,
+} from "./types";
+
+const CATEGORY_LABELS: Record<ReconciliationDiffCategory, string> = {
+  match: "match",
+  missing: "missing",
+  failed_mismatch: "status mismatch",
+  amount_mismatch: "amount mismatch",
+  still_pending: "still pending",
+  unexpected: "unexpected",
+};
+
+const CATEGORY_RANK: Record<ReconciliationDiffCategory, number> = {
+  unexpected: 0,
+  failed_mismatch: 1,
+  amount_mismatch: 2,
+  missing: 3,
+  still_pending: 4,
+  match: 5,
+};
+
+export interface FormatReconciliationDiffOptions {
+  /** Indent prefix used for each entry line. Defaults to `"  "`. */
+  indent?: string;
+  /** Per-line terminator. Defaults to `"\n"`. */
+  newline?: string;
+}
+
+function formatCountSummary(counts: ReconciliationDiffResult["counts"]): string {
+  const interesting = (Object.keys(counts) as ReconciliationDiffCategory[])
+    .filter((c) => counts[c] > 0 && c !== "match" && c !== "still_pending")
+    .sort((a, b) => CATEGORY_RANK[a] - CATEGORY_RANK[b]);
+
+  const routine = counts.match + counts.still_pending;
+
+  const parts: string[] = [];
+  if (routine > 0) parts.push(`${routine} routine`);
+  for (const category of interesting) {
+    parts.push(`${counts[category]} ${CATEGORY_LABELS[category]}`);
+  }
+  return parts.length > 0 ? parts.join(", ") : "no entries";
+}
+
+/**
+ * Render a `ReconciliationDiffResult` as a multi-line, grep-friendly
+ * string suitable for logs, CLI output, or Slack notifications.
+ */
+export function formatReconciliationDiff(
+  result: ReconciliationDiffResult,
+  options: FormatReconciliationDiffOptions = {},
+): string {
+  const indent = options.indent ?? "  ";
+  const newline = options.newline ?? "\n";
+
+  const status = result.isFullyReconciled
+    ? "fully reconciled"
+    : "needs attention";
+
+  const header = `reconciliation: ${status} \u2014 ${formatCountSummary(result.counts)}`;
+
+  const sortedEntries = result.entries
+    .slice()
+    .sort((a, b) => CATEGORY_RANK[a.category] - CATEGORY_RANK[b.category]);
+
+  const lines = sortedEntries.map(
+    (entry) =>
+      `${indent}${entry.recipient}: ${CATEGORY_LABELS[entry.category]} \u2014 ${entry.reason}`,
+  );
+
+  return lines.length > 0
+    ? [header, ...lines].join(newline)
+    : header + newline;
+}

--- a/lib/reconciliation/mockObserved.ts
+++ b/lib/reconciliation/mockObserved.ts
@@ -1,0 +1,101 @@
+/**
+ * Synthesizes the inputs the SDK reconciliation helpers need from the
+ * dashboard's existing mock payroll-run + employee data.
+ *
+ * The dashboard does not (yet) call the live SDK. To make the new
+ * `generateReconciliationDiff` / `formatReconciliationDiff` helpers
+ * useful in the reconciliation panel today, this module builds:
+ *
+ *   - an "expected" outcomes list (what the client recorded for each
+ *     employee in the run), and
+ *   - a synthesized "observed" on-chain state whose categories
+ *     reflect the run's status.
+ *
+ * Behaviour by `run.status`:
+ *
+ *   - `"verified"`  → every employee observed as confirmed → all `match`
+ *   - `"pending"`   → every employee observed as not_found → all `missing`
+ *   - `"failed"`    → first employee observed as confirmed (status
+ *                     mismatch), the rest as not_found (missing) so the
+ *                     operator can see both categories at once
+ *   - `"cancelled"` → all observed as not_found → all `missing`
+ *
+ * All amounts are converted from the dashboard's dollars (number) to
+ * the SDK's stroops (bigint) at the helper boundary so the rest of the
+ * stack stays unit-clean.
+ */
+import type {
+  ObservedPaymentState,
+  ReconciliationDiffResult,
+} from "./types";
+import { generateReconciliationDiff } from "./ReconciliationDiffGenerator";
+import type { Employee, PayrollRun } from "@/types/models";
+
+const STROOPS_PER_DOLLAR = BigInt(10_000_000);
+const DEMO_ASSET = "native";
+
+function toStroops(dollars: number): bigint {
+  return BigInt(Math.round(dollars * Number(STROOPS_PER_DOLLAR)));
+}
+
+export interface SynthesizedReconciliation {
+  expected: Parameters<typeof generateReconciliationDiff>[0];
+  observed: ObservedPaymentState[];
+}
+
+export function synthesizeReconciliation(
+  run: PayrollRun,
+  employees: Employee[],
+  now: number = Date.now(),
+): SynthesizedReconciliation {
+  const results = employees.map((emp) => ({
+    recipient: emp.address,
+    amount: toStroops(emp.salary),
+    asset: DEMO_ASSET,
+    status:
+      run.status === "verified"
+        ? ("success" as const)
+        : run.status === "failed"
+          ? ("failure" as const)
+          : ("pending" as const),
+    txHash: run.transactionHash ?? undefined,
+  }));
+
+  const observed: ObservedPaymentState[] = employees.map((emp, idx) => {
+    const base = {
+      recipient: emp.address,
+      amount: toStroops(emp.salary),
+      asset: DEMO_ASSET,
+      observedAt: now,
+    } as const;
+
+    if (run.status === "verified") {
+      return { ...base, onChainStatus: "confirmed" as const };
+    }
+    if (run.status === "failed") {
+      // First employee: client says it failed but chain shows it confirmed
+      // (duplicate-submission / stale-client pattern).
+      if (idx === 0) {
+        return { ...base, onChainStatus: "confirmed" as const };
+      }
+      return { ...base, onChainStatus: "not_found" as const };
+    }
+    return { ...base, onChainStatus: "not_found" as const };
+  });
+
+  return { expected: { results }, observed };
+}
+
+/**
+ * Convenience wrapper that runs synthesis + diff generation. The UI calls
+ * `formatReconciliationDiff(result)` separately so the formattable string
+ * can be recomputed lazily and cached.
+ */
+export function buildReconciliationDiff(
+  run: PayrollRun,
+  employees: Employee[],
+  now: number = Date.now(),
+): ReconciliationDiffResult {
+  const { expected, observed } = synthesizeReconciliation(run, employees, now);
+  return generateReconciliationDiff(expected, observed);
+}

--- a/lib/reconciliation/types.ts
+++ b/lib/reconciliation/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Vendored copy of `@zk-payroll/core`'s `reconciliation/types.ts` — see
+ * `lib/reconciliation/format.ts` for context on why this is vendored.
+ */
+
+export interface ObservedPaymentState {
+  /** Stellar address of the payment recipient. */
+  recipient: string;
+  /** Observed payment amount in stroops, when determinable. */
+  amount?: bigint;
+  /** Asset identifier (e.g. "native" or a Soroban token contract ID). */
+  asset?: string;
+  /** Transaction hash this observation is keyed on, when known. */
+  txHash?: string;
+  /** What the chain/contract actually shows for this payment. */
+  onChainStatus: "confirmed" | "failed" | "not_found";
+  /** Epoch ms when this observation was made. */
+  observedAt: number;
+}
+
+export type ReconciliationDiffCategory =
+  | "match"
+  | "missing"
+  | "failed_mismatch"
+  | "amount_mismatch"
+  | "still_pending"
+  | "unexpected";
+
+export interface ReconciliationDiffEntry {
+  recipient: string;
+  category: ReconciliationDiffCategory;
+  expected?: {
+    amount: bigint;
+    asset: string;
+    status: "success" | "failure" | "pending";
+    txHash?: string;
+  };
+  observed?: ObservedPaymentState;
+  /** Human-readable explanation of why this entry was classified this way. */
+  reason: string;
+}
+
+export interface ReconciliationDiffResult {
+  entries: ReconciliationDiffEntry[];
+  counts: Record<ReconciliationDiffCategory, number>;
+  /** True only when every entry is "match" or "still_pending". */
+  isFullyReconciled: boolean;
+  generatedAt: number;
+}


### PR DESCRIPTION
## Summary

Wires the new SDK reconciliation-diff helpers into the dashboard payroll-run detail page so operators can view and copy a grep-friendly diff between the client-recorded outcomes and (synthesized) observed on-chain state for any run.

## Why

Per the original follow-up: a reconciliation diff is essential for fast operational debugging. The SDK now provides generateReconciliationDiff and formatReconciliationDiff (zk-payroll-sdk PR #243); this PR makes them visible inside the dashboard so the diff can be triaged without leaving the run-detail view.

## What

- **Vendored SDK helpers under lib/reconciliation/** - types.ts, format.ts, ReconciliationDiffGenerator.ts. Vendored (not added as an npm dependency) because the SDK package.json main/types paths currently point at dist/index.{js,d.ts} while tsc emits into dist/src/... (rootDir inferred from the include list). The helpers are pure with no transitive runtime deps, so vendoring is safe and isolated; once the SDK packaging is fixed this folder can be replaced with a real @zk-payroll/core dependency.
- **lib/reconciliation/mockObserved.ts** - synthesizes a PayrollExecutionSummary and ObservedPaymentState[] from a PayrollRun + Employee[], mapping run status to realistic reconciliation categories: verified -> all match, failed -> mix of failed_mismatch + missing, pending/cancelled -> all still_pending. Dollar amounts are converted to bigint stroops at the helper boundary.
- **components/features/payroll/ReconciliationDiffPanel.tsx** - operator-facing card showing the formatted diff in a monospace block with a one-click copy-to-clipboard (async navigator.clipboard.writeText with a document.execCommand fallback for older browsers, plus a sonner toast on success/error). Always renders inline so the copy button is immediately reachable. Carries an explicit privacy warning about unredacted stroops.
- **components/features/payroll/PayrollRunDetail.tsx** - mounts ReconciliationDiffPanel between the employee-results table and the footer.

## Tests

- __tests__/lib/reconciliation/format.test.ts - 6 tests covering header line, status string, category sort order, fully-reconciled + no-entries cases, custom indent/newline options, purity.
- __tests__/lib/reconciliation/mockObserved.test.ts - 6 tests covering the stroop conversion, the verified/failed/pending/cancelled synthesis mappings, and the txHash passthrough.
- __tests__/components/ReconciliationDiffPanel.test.tsx - 10 tests covering render, summary text, fully-reconciled badge, needs-attention badge, pre rendering, clipboard write, execCommand fallback, the Copied label toggle, the rejection path keeping the button in Copy state, and the privacy notice.

## CI

- npm run typecheck - clean.
- npm run lint - clean.
- npm test -- __tests__/components/ReconciliationDiffPanel.test.tsx __tests__/lib/reconciliation - 22/22 passing.
