### PR TITLE
feat: multi-asset payroll orchestration and reconciliation

### DIFF
--- a/__tests__/multi-asset-payroll.test.tsx
+++ b/__tests__/multi-asset-payroll.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  groupEmployeesByAsset,
+  deriveRunStatus,
+  buildReconciliation,
+  formatAssetAmount,
+  assetLabel,
+  isNative,
+} from "@/lib/payroll/multiAsset";
+import type {
+  AssetGroup,
+  MultiAssetPayrollRun,
+} from "@/types/models";
+import { MOCK_MULTI_ASSET_RUNS } from "@/lib/api/mockData";
+
+// ── lib/payroll/multiAsset unit tests ────────────────────────────────────────
+
+describe("assetLabel", () => {
+  it("labels native XLM correctly", () => {
+    expect(assetLabel({ code: "XLM" })).toBe("XLM (native)");
+  });
+
+  it("labels issued assets with their code", () => {
+    expect(assetLabel({ code: "USDC", issuer: "GABC" })).toBe("USDC");
+  });
+});
+
+describe("isNative", () => {
+  it("returns true for XLM without issuer", () => {
+    expect(isNative({ code: "XLM" })).toBe(true);
+  });
+
+  it("returns false for issued XLM-like token", () => {
+    expect(isNative({ code: "XLM", issuer: "GABC" })).toBe(false);
+  });
+});
+
+describe("formatAssetAmount", () => {
+  it("formats whole numbers with 2 decimal places", () => {
+    expect(formatAssetAmount(1000, "USDC")).toContain("1,000");
+    expect(formatAssetAmount(1000, "USDC")).toContain("USDC");
+  });
+
+  it("formats fractional amounts", () => {
+    const result = formatAssetAmount(123.456789, "XLM");
+    expect(result).toContain("XLM");
+  });
+});
+
+describe("groupEmployeesByAsset", () => {
+  const employees = [
+    { employeeId: "e1", name: "Alice", address: "GA1", amount: 1000, salaryCommitment: "0x1", assetCode: "USDC", assetIssuer: "GISSUER" },
+    { employeeId: "e2", name: "Bob", address: "GB2", amount: 2000, salaryCommitment: "0x2", assetCode: "USDC", assetIssuer: "GISSUER" },
+    { employeeId: "e3", name: "Carol", address: "GC3", amount: 500, salaryCommitment: "0x3", assetCode: "XLM" },
+  ];
+
+  const balances = new Map<string, number>([
+    ["USDC:GISSUER", 5000],
+    ["XLM", 200],
+  ]);
+
+  it("groups employees into correct asset buckets", () => {
+    const groups = groupEmployeesByAsset(employees, balances);
+    expect(groups).toHaveLength(2);
+    const usdc = groups.find((g) => g.asset.code === "USDC")!;
+    const xlm = groups.find((g) => g.asset.code === "XLM")!;
+    expect(usdc.employees).toHaveLength(2);
+    expect(xlm.employees).toHaveLength(1);
+  });
+
+  it("computes correct totals per group", () => {
+    const groups = groupEmployeesByAsset(employees, balances);
+    const usdc = groups.find((g) => g.asset.code === "USDC")!;
+    expect(usdc.totalAmount).toBe(3000);
+  });
+
+  it("marks group as funded when balance is sufficient", () => {
+    const groups = groupEmployeesByAsset(employees, balances);
+    const usdc = groups.find((g) => g.asset.code === "USDC")!;
+    expect(usdc.status).toBe("funded");
+    expect(usdc.treasuryReadiness.isFunded).toBe(true);
+    expect(usdc.treasuryReadiness.shortfall).toBe(0);
+  });
+
+  it("marks group as underfunded when balance is insufficient", () => {
+    // XLM balance=200, required=500
+    const groups = groupEmployeesByAsset(employees, balances);
+    const xlm = groups.find((g) => g.asset.code === "XLM")!;
+    expect(xlm.status).toBe("underfunded");
+    expect(xlm.treasuryReadiness.isFunded).toBe(false);
+    expect(xlm.treasuryReadiness.shortfall).toBe(300);
+  });
+
+  it("handles missing balance key as underfunded with full shortfall", () => {
+    const groups = groupEmployeesByAsset(employees, new Map());
+    const usdc = groups.find((g) => g.asset.code === "USDC")!;
+    expect(usdc.status).toBe("underfunded");
+    expect(usdc.treasuryReadiness.shortfall).toBe(3000);
+  });
+});
+
+describe("deriveRunStatus", () => {
+  const makeGroup = (status: AssetGroup["status"]): AssetGroup => ({
+    asset: { code: "USDC" },
+    employees: [],
+    totalAmount: 0,
+    transactionCount: 0,
+    status,
+    treasuryReadiness: { asset: { code: "USDC" }, requiredAmount: 0, availableBalance: 0, isFunded: true, shortfall: 0 },
+  });
+
+  it("returns draft for empty groups", () => {
+    expect(deriveRunStatus([])).toBe("draft");
+  });
+
+  it("returns underfunded when any group is underfunded", () => {
+    expect(deriveRunStatus([makeGroup("funded"), makeGroup("underfunded")])).toBe("underfunded");
+  });
+
+  it("returns ready when all groups are funded", () => {
+    expect(deriveRunStatus([makeGroup("funded"), makeGroup("funded")])).toBe("ready");
+  });
+
+  it("returns succeeded when all groups succeeded", () => {
+    expect(deriveRunStatus([makeGroup("succeeded"), makeGroup("succeeded")])).toBe("succeeded");
+  });
+
+  it("returns partial when some succeed and some fail", () => {
+    expect(deriveRunStatus([makeGroup("succeeded"), makeGroup("failed")])).toBe("partial");
+  });
+
+  it("returns failed when all groups failed", () => {
+    expect(deriveRunStatus([makeGroup("failed"), makeGroup("failed")])).toBe("failed");
+  });
+});
+
+describe("buildReconciliation", () => {
+  it("returns a reconciliation with one group per asset group in the run", () => {
+    const run = MOCK_MULTI_ASSET_RUNS[0]; // succeeded run
+    const recon = buildReconciliation(run);
+    expect(recon.runId).toBe(run.id);
+    expect(recon.groups).toHaveLength(run.assetGroups.length);
+  });
+
+  it("marks entries as confirmed for succeeded groups", () => {
+    const run = MOCK_MULTI_ASSET_RUNS[0];
+    const recon = buildReconciliation(run);
+    for (const group of recon.groups) {
+      for (const entry of group.entries) {
+        expect(entry.status).toBe("confirmed");
+        expect(entry.confirmedAmount).toBe(entry.expectedAmount);
+      }
+    }
+  });
+
+  it("marks entries as missing for failed groups", () => {
+    const run = MOCK_MULTI_ASSET_RUNS[1]; // partial run — USDC group failed
+    const recon = buildReconciliation(run);
+    const usdcGroup = recon.groups.find((g) => g.asset.code === "USDC")!;
+    expect(usdcGroup.status).toBe("failed");
+    for (const entry of usdcGroup.entries) {
+      expect(entry.status).toBe("missing");
+      expect(entry.confirmedAmount).toBe(0);
+    }
+  });
+
+  it("canExportAudit is true when all groups are complete or partial", () => {
+    const run = MOCK_MULTI_ASSET_RUNS[0];
+    const recon = buildReconciliation(run);
+    expect(recon.canExportAudit).toBe(true);
+  });
+
+  it("canExportAudit is false when any group is still pending", () => {
+    const run = MOCK_MULTI_ASSET_RUNS[2]; // underfunded/draft
+    // Override status to make it at least partially executable
+    const modified: MultiAssetPayrollRun = {
+      ...run,
+      status: "partial",
+      assetGroups: run.assetGroups.map((g, i) => ({
+        ...g,
+        status: i === 0 ? "succeeded" : "pending",
+      })),
+    };
+    const recon = buildReconciliation(modified);
+    expect(recon.canExportAudit).toBe(false);
+  });
+});
+
+// ── Single-asset payroll run (no grouping complexity) ─────────────────────────
+
+describe("single-asset happy path", () => {
+  it("a run with one asset group and fully funded treasury returns ready status", () => {
+    const employees = [
+      { employeeId: "e1", name: "Alice", address: "GA1", amount: 1000, salaryCommitment: "0x1", assetCode: "XLM" },
+    ];
+    const balances = new Map([["XLM", 5000]]);
+    const [group] = groupEmployeesByAsset(employees, balances);
+    expect(deriveRunStatus([group])).toBe("ready");
+  });
+});
+
+// ── Partially funded multi-asset run ─────────────────────────────────────────
+
+describe("partially funded run blocks submission", () => {
+  it("returns underfunded when any group has insufficient balance", () => {
+    const employees = [
+      { employeeId: "e1", name: "Alice", address: "GA1", amount: 10000, salaryCommitment: "0x1", assetCode: "USDC", assetIssuer: "GABC" },
+      { employeeId: "e2", name: "Bob", address: "GB2", amount: 500, salaryCommitment: "0x2", assetCode: "XLM" },
+    ];
+    const balances = new Map<string, number>([
+      ["USDC:GABC", 1000], // underfunded by 9000
+      ["XLM", 5000],
+    ]);
+    const groups = groupEmployeesByAsset(employees, balances);
+    expect(deriveRunStatus(groups)).toBe("underfunded");
+  });
+});

--- a/app/payroll/multi-asset/[runId]/page.tsx
+++ b/app/payroll/multi-asset/[runId]/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, notFound } from "next/navigation";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import MultiAssetPayrollReview from "@/components/features/payroll/MultiAssetPayrollReview";
+import { MOCK_MULTI_ASSET_RUNS } from "@/lib/api/mockData";
+
+export default function MultiAssetPayrollDetailPage() {
+  const { runId } = useParams<{ runId: string }>();
+  const [runs, setRuns] = useState(MOCK_MULTI_ASSET_RUNS);
+
+  const run = runs.find((r) => r.id === runId);
+  if (!run) return notFound();
+
+  const handleSubmit = () => {
+    setRuns((prev) =>
+      prev.map((r) =>
+        r.id === runId
+          ? {
+              ...r,
+              status: "executing",
+              assetGroups: r.assetGroups.map((g) => ({ ...g, status: "executing" })),
+            }
+          : r,
+      ),
+    );
+    // In production this would call the API and then poll for status.
+    setTimeout(() => {
+      setRuns((prev) =>
+        prev.map((r) =>
+          r.id === runId
+            ? {
+                ...r,
+                status: "succeeded",
+                executedAt: new Date().toISOString(),
+                assetGroups: r.assetGroups.map((g) => ({
+                  ...g,
+                  status: "succeeded",
+                  txHash: `sim_${g.asset.code}_${Date.now()}`,
+                  executedAt: new Date().toISOString(),
+                })),
+              }
+            : r,
+        ),
+      );
+    }, 2500);
+  };
+
+  const handleRetryGroup = (assetCode: string) => {
+    setRuns((prev) =>
+      prev.map((r) =>
+        r.id === runId
+          ? {
+              ...r,
+              assetGroups: r.assetGroups.map((g) =>
+                g.asset.code === assetCode ? { ...g, status: "executing" } : g,
+              ),
+            }
+          : r,
+      ),
+    );
+  };
+
+  const currentRun = runs.find((r) => r.id === runId)!;
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <MultiAssetPayrollReview
+          run={currentRun}
+          onSubmit={handleSubmit}
+          onRetryGroup={handleRetryGroup}
+        />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/payroll/multi-asset/[runId]/reconciliation/page.tsx
+++ b/app/payroll/multi-asset/[runId]/reconciliation/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams, notFound } from "next/navigation";
+import Link from "next/link";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import MultiAssetReconciliationView from "@/components/features/payroll/MultiAssetReconciliation";
+import { MOCK_MULTI_ASSET_RUNS } from "@/lib/api/mockData";
+import { buildReconciliation } from "@/lib/payroll/multiAsset";
+
+export default function MultiAssetReconciliationPage() {
+  const { runId } = useParams<{ runId: string }>();
+  const run = MOCK_MULTI_ASSET_RUNS.find((r) => r.id === runId);
+
+  if (!run) return notFound();
+
+  // Only runs that have finished execution (partial or succeeded) have
+  // reconciliation data.  Draft / underfunded runs redirect back to review.
+  if (run.status === "draft" || run.status === "ready" || run.status === "underfunded") {
+    return (
+      <DashboardLayout>
+        <div className="max-w-2xl mx-auto px-4 py-16 text-center text-gray-500 text-sm">
+          <p className="font-medium text-gray-700 mb-2">Reconciliation not yet available</p>
+          <p>This run has not been executed yet. Submit it first to generate a reconciliation report.</p>
+          <Link
+            href={`/payroll/multi-asset/${runId}`}
+            className="mt-4 inline-block text-indigo-600 hover:underline text-sm font-medium"
+          >
+            ← Back to run review
+          </Link>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const reconciliation = useMemo(() => buildReconciliation(run), [run]);
+
+  const handleExportAudit = () => {
+    // Build CSV
+    const rows: string[] = [
+      "Asset,Employee,Expected,Confirmed,Status,TxHash,ConfirmedAt",
+    ];
+    for (const group of reconciliation.groups) {
+      for (const entry of group.entries) {
+        rows.push(
+          [
+            group.asset.code,
+            entry.name,
+            entry.expectedAmount,
+            entry.confirmedAmount,
+            entry.status,
+            entry.txHash ?? "",
+            entry.confirmedAt ?? "",
+          ].join(","),
+        );
+      }
+    }
+    const blob = new Blob([rows.join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `reconciliation-${run.id}-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="mb-4">
+          <Link
+            href={`/payroll/multi-asset/${runId}`}
+            className="text-sm text-gray-500 hover:text-gray-800 transition"
+          >
+            ← Back to run review
+          </Link>
+        </div>
+        <MultiAssetReconciliationView
+          reconciliation={reconciliation}
+          onExportAudit={reconciliation.canExportAudit ? handleExportAudit : undefined}
+        />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/payroll/multi-asset/page.tsx
+++ b/app/payroll/multi-asset/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Coins,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import { MOCK_MULTI_ASSET_RUNS } from "@/lib/api/mockData";
+import type { MultiAssetPayrollRun } from "@/types/models";
+import { formatAssetAmount } from "@/lib/payroll/multiAsset";
+
+const STATUS_CONFIG: Record<
+  MultiAssetPayrollRun["status"],
+  { label: string; colorClass: string; icon: React.ReactNode }
+> = {
+  draft: { label: "Draft", colorClass: "bg-gray-100 text-gray-700", icon: <Clock className="w-3.5 h-3.5" /> },
+  ready: { label: "Ready", colorClass: "bg-blue-100 text-blue-700", icon: <CheckCircle2 className="w-3.5 h-3.5" /> },
+  underfunded: { label: "Underfunded", colorClass: "bg-yellow-100 text-yellow-800", icon: <AlertTriangle className="w-3.5 h-3.5" /> },
+  executing: { label: "Executing", colorClass: "bg-blue-100 text-blue-700", icon: <RefreshCw className="w-3.5 h-3.5 animate-spin" /> },
+  succeeded: { label: "Succeeded", colorClass: "bg-green-100 text-green-800", icon: <CheckCircle2 className="w-3.5 h-3.5" /> },
+  partial: { label: "Partial", colorClass: "bg-orange-100 text-orange-800", icon: <AlertTriangle className="w-3.5 h-3.5" /> },
+  failed: { label: "Failed", colorClass: "bg-red-100 text-red-800", icon: <XCircle className="w-3.5 h-3.5" /> },
+};
+
+function RunCard({ run }: { run: MultiAssetPayrollRun }) {
+  const cfg = STATUS_CONFIG[run.status];
+  const assetCodes = run.assetGroups.map((g) => g.asset.code).join(", ");
+
+  return (
+    <Link
+      href={`/payroll/multi-asset/${run.id}`}
+      className="block rounded-xl border border-gray-200 bg-white p-5 hover:shadow-md
+                 hover:border-indigo-200 transition-all group"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-gray-900 truncate group-hover:text-indigo-700 transition">
+            {run.label}
+          </p>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {run.totalEmployees} employees · {run.assetGroups.length} asset group
+            {run.assetGroups.length !== 1 ? "s" : ""} ({assetCodes})
+          </p>
+        </div>
+        <div className="flex items-center gap-2 ml-4 flex-shrink-0">
+          <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold ${cfg.colorClass}`}>
+            {cfg.icon} {cfg.label}
+          </span>
+          <ChevronRight className="w-4 h-4 text-gray-400 group-hover:text-indigo-500 transition" />
+        </div>
+      </div>
+
+      {/* Per-asset totals */}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {run.assetGroups.map((g) => (
+          <div
+            key={g.asset.code}
+            className="flex items-center gap-1.5 rounded-full bg-gray-50 border border-gray-100 px-3 py-1 text-xs text-gray-700"
+          >
+            <Coins className="w-3 h-3 text-indigo-400" />
+            <span className="font-semibold">{g.asset.code}</span>
+            <span className="text-gray-500">{formatAssetAmount(g.totalAmount, g.asset.code)}</span>
+            {g.status === "underfunded" && (
+              <AlertTriangle className="w-3 h-3 text-yellow-500" />
+            )}
+            {g.status === "failed" && <XCircle className="w-3 h-3 text-red-500" />}
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-gray-400 mt-3">
+        Created{" "}
+        {new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+          new Date(run.createdAt),
+        )}
+        {run.executedAt && (
+          <>
+            {" "}· Executed{" "}
+            {new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+              new Date(run.executedAt),
+            )}
+          </>
+        )}
+      </p>
+    </Link>
+  );
+}
+
+export default function MultiAssetPayrollListPage() {
+  const runs = MOCK_MULTI_ASSET_RUNS;
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Multi-Asset Payroll Runs</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Plan, review, and reconcile payroll runs that include multiple Stellar assets.
+            </p>
+          </div>
+          <button
+            disabled
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white
+                       opacity-50 cursor-not-allowed"
+            title="New run creation coming soon"
+          >
+            + New run
+          </button>
+        </div>
+
+        {/* Underfunded warning banner */}
+        {runs.some((r) => r.status === "underfunded") && (
+          <div className="mb-4 flex items-start gap-3 rounded-lg bg-yellow-50 border border-yellow-200 p-4 text-sm text-yellow-800">
+            <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+            <div>
+              <span className="font-semibold">Action required: </span>
+              {runs.filter((r) => r.status === "underfunded").length} run
+              {runs.filter((r) => r.status === "underfunded").length !== 1 ? "s are" : " is"}{" "}
+              underfunded. Fund the relevant treasury accounts before the next payroll cycle.
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {runs.length === 0 ? (
+            <div className="text-center py-16 text-gray-400 text-sm">
+              No multi-asset payroll runs yet.
+            </div>
+          ) : (
+            runs.map((run) => <RunCard key={run.id} run={run} />)
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/components/features/payroll/MultiAssetPayrollReview.tsx
+++ b/components/features/payroll/MultiAssetPayrollReview.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Coins,
+  RefreshCw,
+  ShieldAlert,
+  Users,
+  XCircle,
+} from "lucide-react";
+import type { AssetGroup, MultiAssetPayrollRun } from "@/types/models";
+import { assetLabel, formatAssetAmount, groupRiskLabel } from "@/lib/payroll/multiAsset";
+
+// ── Status helpers ────────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  MultiAssetPayrollRun["status"],
+  { label: string; colorClass: string; icon: React.ReactNode }
+> = {
+  draft: { label: "Draft", colorClass: "bg-gray-100 text-gray-700", icon: <Clock className="w-3.5 h-3.5" /> },
+  ready: { label: "Ready", colorClass: "bg-blue-100 text-blue-700", icon: <CheckCircle2 className="w-3.5 h-3.5" /> },
+  underfunded: { label: "Underfunded", colorClass: "bg-yellow-100 text-yellow-800", icon: <AlertTriangle className="w-3.5 h-3.5" /> },
+  executing: { label: "Executing", colorClass: "bg-blue-100 text-blue-700", icon: <RefreshCw className="w-3.5 h-3.5 animate-spin" /> },
+  succeeded: { label: "Succeeded", colorClass: "bg-green-100 text-green-800", icon: <CheckCircle2 className="w-3.5 h-3.5" /> },
+  partial: { label: "Partial", colorClass: "bg-orange-100 text-orange-800", icon: <AlertTriangle className="w-3.5 h-3.5" /> },
+  failed: { label: "Failed", colorClass: "bg-red-100 text-red-800", icon: <XCircle className="w-3.5 h-3.5" /> },
+};
+
+const GROUP_STATUS_CONFIG: Record<
+  AssetGroup["status"],
+  { colorClass: string; icon: React.ReactNode }
+> = {
+  pending: { colorClass: "bg-gray-100 text-gray-600", icon: <Clock className="w-3 h-3" /> },
+  funded: { colorClass: "bg-blue-50 text-blue-700", icon: <CheckCircle2 className="w-3 h-3" /> },
+  underfunded: { colorClass: "bg-yellow-50 text-yellow-800", icon: <AlertTriangle className="w-3 h-3" /> },
+  executing: { colorClass: "bg-blue-100 text-blue-800", icon: <RefreshCw className="w-3 h-3 animate-spin" /> },
+  succeeded: { colorClass: "bg-green-50 text-green-800", icon: <CheckCircle2 className="w-3 h-3" /> },
+  failed: { colorClass: "bg-red-50 text-red-800", icon: <XCircle className="w-3 h-3" /> },
+  partial: { colorClass: "bg-orange-50 text-orange-800", icon: <AlertTriangle className="w-3 h-3" /> },
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function TreasuryReadinessBar({ group }: { group: AssetGroup }) {
+  const { availableBalance, requiredAmount, isFunded } = group.treasuryReadiness;
+  const pct = Math.min((availableBalance / requiredAmount) * 100, 100);
+
+  return (
+    <div className="mt-2">
+      <div className="flex justify-between text-xs text-gray-500 mb-1">
+        <span>Treasury readiness</span>
+        <span className={isFunded ? "text-green-600 font-medium" : "text-red-600 font-medium"}>
+          {formatAssetAmount(availableBalance, group.asset.code)} available /{" "}
+          {formatAssetAmount(requiredAmount, group.asset.code)} required
+        </span>
+      </div>
+      <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${isFunded ? "bg-green-500" : "bg-red-400"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {!isFunded && (
+        <p className="text-xs text-red-600 mt-1 flex items-center gap-1">
+          <ShieldAlert className="w-3 h-3" />
+          Shortfall of {formatAssetAmount(group.treasuryReadiness.shortfall, group.asset.code)} — fund treasury before submitting
+        </p>
+      )}
+    </div>
+  );
+}
+
+function AssetGroupCard({ group }: { group: AssetGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  const cfg = GROUP_STATUS_CONFIG[group.status];
+  const riskLabel = groupRiskLabel(group);
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-white hover:bg-gray-50 transition text-left"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center w-8 h-8 rounded-full bg-indigo-50">
+            <Coins className="w-4 h-4 text-indigo-600" />
+          </div>
+          <div>
+            <p className="font-semibold text-sm text-gray-900">{assetLabel(group.asset)}</p>
+            <p className="text-xs text-gray-500">
+              {group.employees.length} employee{group.employees.length !== 1 ? "s" : ""} ·{" "}
+              {formatAssetAmount(group.totalAmount, group.asset.code)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${cfg.colorClass}`}>
+            {cfg.icon}
+            {group.status}
+          </span>
+          {expanded ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronRight className="w-4 h-4 text-gray-400" />}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-100 px-4 py-3 bg-gray-50 space-y-3">
+          <TreasuryReadinessBar group={group} />
+
+          {riskLabel && (
+            <div className="text-xs text-orange-700 bg-orange-50 border border-orange-100 rounded px-3 py-2 flex items-start gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+              {riskLabel}
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Employees</p>
+            {group.employees.map((emp) => (
+              <div
+                key={emp.employeeId}
+                className="flex items-center justify-between text-sm py-1 border-b border-gray-100 last:border-none"
+              >
+                <div>
+                  <span className="font-medium text-gray-800">{emp.name}</span>
+                  <span className="ml-2 text-xs text-gray-400 font-mono">
+                    {emp.address.slice(0, 6)}…{emp.address.slice(-4)}
+                  </span>
+                </div>
+                <span className="font-mono text-xs text-gray-700">
+                  {formatAssetAmount(emp.amount, group.asset.code)}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {group.txHash && (
+            <p className="text-xs text-gray-500">
+              Tx: <span className="font-mono">{group.txHash.slice(0, 16)}…</span>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface MultiAssetPayrollReviewProps {
+  run: MultiAssetPayrollRun;
+  onSubmit?: () => void;
+  onRetryGroup?: (assetCode: string) => void;
+}
+
+export default function MultiAssetPayrollReview({
+  run,
+  onSubmit,
+  onRetryGroup,
+}: MultiAssetPayrollReviewProps) {
+  const statusCfg = STATUS_CONFIG[run.status];
+  const hasFundingIssue = run.assetGroups.some((g) => g.status === "underfunded");
+  const hasFailedGroup = run.assetGroups.some((g) => g.status === "failed");
+  const canSubmit = run.status === "ready" && run.proofStatus === "ready";
+
+  const totalByAsset = run.assetGroups.map((g) => ({
+    assetCode: g.asset.code,
+    total: g.totalAmount,
+  }));
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">{run.label}</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {run.totalEmployees} employees · {run.assetGroups.length} asset group{run.assetGroups.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <span className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ${statusCfg.colorClass}`}>
+          {statusCfg.icon}
+          {statusCfg.label}
+        </span>
+      </div>
+
+      {/* Global warnings */}
+      {hasFundingIssue && (
+        <div className="flex items-start gap-3 rounded-lg bg-yellow-50 border border-yellow-200 p-4 text-sm text-yellow-800">
+          <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="font-semibold">One or more asset groups are underfunded</p>
+            <p className="text-yellow-700 mt-0.5">
+              Fund all underfunded treasury accounts before submitting. Submitting while underfunded
+              will block those groups from executing.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {hasFailedGroup && (
+        <div className="flex items-start gap-3 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
+          <XCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="font-semibold">Partial execution — one or more groups failed</p>
+            <p className="text-red-700 mt-0.5">
+              Successful groups are shown as Succeeded. Failed groups can be retried individually
+              without re-processing already completed payments.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Totals summary */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <p className="text-xs text-gray-500">Total employees</p>
+          <p className="text-2xl font-bold text-gray-900 flex items-center gap-1.5">
+            <Users className="w-5 h-5 text-indigo-500" />
+            {run.totalEmployees}
+          </p>
+        </div>
+        {totalByAsset.map((t) => (
+          <div key={t.assetCode} className="rounded-lg border border-gray-200 bg-white p-3">
+            <p className="text-xs text-gray-500">{t.assetCode} total</p>
+            <p className="text-lg font-bold text-gray-900 font-mono">
+              {formatAssetAmount(t.total, t.assetCode)}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Asset groups */}
+      <div className="space-y-2">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Asset Groups</p>
+        {run.assetGroups.map((group) => (
+          <div key={group.asset.code}>
+            <AssetGroupCard group={group} />
+            {group.status === "failed" && onRetryGroup && (
+              <div className="mt-1 flex justify-end">
+                <button
+                  onClick={() => onRetryGroup(group.asset.code)}
+                  className="text-xs text-indigo-600 hover:text-indigo-800 font-medium flex items-center gap-1"
+                >
+                  <RefreshCw className="w-3 h-3" />
+                  Retry {group.asset.code} group
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Proof status */}
+      <div className="flex items-center gap-2 text-sm rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+        <ShieldAlert className="w-4 h-4 text-indigo-500" />
+        <span className="text-gray-700">
+          ZK proof:{" "}
+          <span
+            className={`font-semibold ${
+              run.proofStatus === "ready"
+                ? "text-green-700"
+                : run.proofStatus === "generating"
+                ? "text-blue-600"
+                : run.proofStatus === "expired"
+                ? "text-red-600"
+                : "text-gray-500"
+            }`}
+          >
+            {run.proofStatus === "ready"
+              ? "Ready"
+              : run.proofStatus === "generating"
+              ? "Generating…"
+              : run.proofStatus === "expired"
+              ? "Expired — regenerate before submission"
+              : "Not generated"}
+          </span>
+        </span>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-2">
+        <Link
+          href="/payroll/multi-asset"
+          className="text-sm text-gray-500 hover:text-gray-800 transition"
+        >
+          ← Back to runs
+        </Link>
+        <div className="flex items-center gap-3">
+          {(run.status === "partial" || run.status === "succeeded") && (
+            <Link
+              href={`/payroll/multi-asset/${run.id}/reconciliation`}
+              className="rounded-lg border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50 transition"
+            >
+              View reconciliation
+            </Link>
+          )}
+          {onSubmit && (
+            <button
+              onClick={onSubmit}
+              disabled={!canSubmit}
+              className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-semibold text-white
+                         hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition"
+            >
+              Submit payroll run
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/payroll/MultiAssetReconciliation.tsx
+++ b/components/features/payroll/MultiAssetReconciliation.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Download,
+  ExternalLink,
+  XCircle,
+} from "lucide-react";
+import type { MultiAssetReconciliation, ReconciliationEntry } from "@/types/models";
+import { assetLabel, formatAssetAmount } from "@/lib/payroll/multiAsset";
+
+// ── Status helpers ────────────────────────────────────────────────────────────
+
+const ENTRY_STATUS_CFG: Record<
+  ReconciliationEntry["status"],
+  { colorClass: string; label: string; icon: React.ReactNode }
+> = {
+  confirmed: { colorClass: "text-green-700 bg-green-50", label: "Confirmed", icon: <CheckCircle2 className="w-3.5 h-3.5" /> },
+  discrepancy: { colorClass: "text-orange-700 bg-orange-50", label: "Discrepancy", icon: <AlertCircle className="w-3.5 h-3.5" /> },
+  missing: { colorClass: "text-red-700 bg-red-50", label: "Missing", icon: <XCircle className="w-3.5 h-3.5" /> },
+};
+
+const GROUP_STATUS_CFG: Record<
+  MultiAssetReconciliation["groups"][number]["status"],
+  { colorClass: string; label: string }
+> = {
+  complete: { colorClass: "bg-green-100 text-green-800", label: "Complete" },
+  partial: { colorClass: "bg-orange-100 text-orange-800", label: "Partial" },
+  failed: { colorClass: "bg-red-100 text-red-800", label: "Failed" },
+  pending: { colorClass: "bg-gray-100 text-gray-700", label: "Pending" },
+};
+
+// ── Entry row ─────────────────────────────────────────────────────────────────
+
+function EntryRow({ entry }: { entry: ReconciliationEntry }) {
+  const cfg = ENTRY_STATUS_CFG[entry.status];
+  const isDiscrepant = entry.status !== "confirmed";
+
+  return (
+    <tr className={`text-sm ${isDiscrepant ? "bg-orange-50/40" : ""}`}>
+      <td className="px-4 py-2.5 font-medium text-gray-800">{entry.name}</td>
+      <td className="px-4 py-2.5 font-mono text-xs text-gray-600">
+        {formatAssetAmount(entry.expectedAmount, entry.assetCode)}
+      </td>
+      <td className="px-4 py-2.5 font-mono text-xs text-gray-600">
+        {entry.confirmedAmount > 0
+          ? formatAssetAmount(entry.confirmedAmount, entry.assetCode)
+          : "—"}
+      </td>
+      <td className="px-4 py-2.5">
+        <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ${cfg.colorClass}`}>
+          {cfg.icon} {cfg.label}
+        </span>
+      </td>
+      <td className="px-4 py-2.5 text-xs text-gray-500">
+        {entry.txHash ? (
+          <span className="font-mono">{entry.txHash.slice(0, 12)}…</span>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td className="px-4 py-2.5 text-xs text-gray-400 whitespace-nowrap">
+        {entry.confirmedAt
+          ? new Intl.DateTimeFormat(undefined, { dateStyle: "short", timeStyle: "short" }).format(
+              new Date(entry.confirmedAt),
+            )
+          : "—"}
+      </td>
+    </tr>
+  );
+}
+
+// ── Group panel ───────────────────────────────────────────────────────────────
+
+function GroupPanel({ group }: { group: MultiAssetReconciliation["groups"][number] }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const cfg = GROUP_STATUS_CFG[group.status];
+  const completionPct =
+    group.totalExpected > 0
+      ? Math.round((group.totalConfirmed / group.totalExpected) * 100)
+      : 0;
+
+  return (
+    <div className="rounded-lg border border-gray-200 overflow-hidden">
+      <button
+        onClick={() => setCollapsed((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 hover:bg-gray-100 transition text-left"
+      >
+        <div className="flex items-center gap-3">
+          <p className="font-semibold text-gray-900 text-sm">{assetLabel(group.asset)}</p>
+          <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${cfg.colorClass}`}>
+            {cfg.label}
+          </span>
+          {group.discrepancyCount > 0 && (
+            <span className="rounded-full px-2 py-0.5 text-xs font-semibold bg-red-100 text-red-700">
+              {group.discrepancyCount} discrepanc{group.discrepancyCount !== 1 ? "ies" : "y"}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-4 text-xs text-gray-500">
+          <span>
+            {formatAssetAmount(group.totalConfirmed, group.asset.code)} /{" "}
+            {formatAssetAmount(group.totalExpected, group.asset.code)} confirmed ({completionPct}%)
+          </span>
+          <span className="text-gray-400">{collapsed ? "▸" : "▾"}</span>
+        </div>
+      </button>
+
+      {/* Completion bar */}
+      <div className="h-1 bg-gray-100">
+        <div
+          className={`h-full transition-all ${
+            group.status === "complete"
+              ? "bg-green-500"
+              : group.status === "failed"
+              ? "bg-red-400"
+              : "bg-orange-400"
+          }`}
+          style={{ width: `${completionPct}%` }}
+        />
+      </div>
+
+      {!collapsed && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-100">
+            <thead className="bg-white">
+              <tr>
+                {["Employee", "Expected", "Confirmed", "Status", "Tx Hash", "Confirmed At"].map(
+                  (h) => (
+                    <th
+                      key={h}
+                      className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap"
+                    >
+                      {h}
+                    </th>
+                  ),
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-50 bg-white">
+              {group.entries.map((entry) => (
+                <EntryRow key={entry.employeeId} entry={entry} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface MultiAssetReconciliationProps {
+  reconciliation: MultiAssetReconciliation;
+  onExportAudit?: () => void;
+}
+
+export default function MultiAssetReconciliationView({
+  reconciliation,
+  onExportAudit,
+}: MultiAssetReconciliationProps) {
+  const totalExpected = reconciliation.groups.reduce((s, g) => s + g.totalExpected, 0);
+  const totalConfirmed = reconciliation.groups.reduce((s, g) => s + g.totalConfirmed, 0);
+  const totalDiscrepancies = reconciliation.groups.reduce((s, g) => s + g.discrepancyCount, 0);
+  const groupsComplete = reconciliation.groups.filter((g) => g.status === "complete").length;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">Reconciliation Report</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Run <span className="font-mono">{reconciliation.runId}</span> · Generated{" "}
+            {new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(
+              new Date(reconciliation.generatedAt),
+            )}
+          </p>
+        </div>
+        {reconciliation.canExportAudit && onExportAudit && (
+          <button
+            onClick={onExportAudit}
+            className="inline-flex items-center gap-2 rounded-lg border border-indigo-200 px-4 py-2
+                       text-sm font-semibold text-indigo-700 hover:bg-indigo-50 transition"
+          >
+            <Download className="w-4 h-4" />
+            Export audit CSV
+          </button>
+        )}
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-3 text-center">
+          <p className="text-xs text-gray-500">Groups complete</p>
+          <p className="text-2xl font-bold text-gray-900">
+            {groupsComplete}/{reconciliation.groups.length}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 text-center">
+          <p className="text-xs text-gray-500">Total employees</p>
+          <p className="text-2xl font-bold text-gray-900">
+            {reconciliation.groups.reduce((s, g) => s + g.entries.length, 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 text-center">
+          <p className="text-xs text-gray-500">Discrepancies</p>
+          <p className={`text-2xl font-bold ${totalDiscrepancies > 0 ? "text-red-600" : "text-green-600"}`}>
+            {totalDiscrepancies}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 text-center">
+          <p className="text-xs text-gray-500">Audit export</p>
+          <p className={`text-sm font-semibold mt-1 ${reconciliation.canExportAudit ? "text-green-700" : "text-gray-400"}`}>
+            {reconciliation.canExportAudit ? "Ready" : "Not available"}
+          </p>
+        </div>
+      </div>
+
+      {/* Per-group panels */}
+      <div className="space-y-3">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          Per-asset breakdown
+        </p>
+        {reconciliation.groups.map((group) => (
+          <GroupPanel key={group.asset.code} group={group} />
+        ))}
+      </div>
+
+      {/* Retry guidance for failed groups */}
+      {reconciliation.groups.some((g) => g.status === "failed" || g.status === "partial") && (
+        <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 text-sm text-orange-800 space-y-2">
+          <p className="font-semibold flex items-center gap-2">
+            <AlertCircle className="w-4 h-4" />
+            Retry guidance
+          </p>
+          <ul className="list-disc list-inside space-y-1 text-orange-700">
+            <li>Confirm the affected employees' trust lines are established for the failed asset.</li>
+            <li>Verify treasury balance covers the shortfall amount.</li>
+            <li>Re-run only the failed asset groups — already-confirmed groups will not be re-processed.</li>
+            <li>
+              For trust-line errors, the employee must accept the asset trust line on-chain before
+              retrying.
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/api/mockData.ts
+++ b/lib/api/mockData.ts
@@ -1,4 +1,4 @@
-import { Employee, Company, PayrollTransaction, PayrollRun, ViewKey, FundingForecast, AuditAccessRequest } from "@/types/models";
+import { Employee, Company, PayrollTransaction, PayrollRun, ViewKey, FundingForecast, AuditAccessRequest, MultiAssetPayrollRun } from "@/types/models";
 
 export const MOCK_EMPLOYEES: Employee[] = [
   {
@@ -240,5 +240,115 @@ export const MOCK_AUDIT_REQUESTS: AuditAccessRequest[] = [
     status: "rejected",
     createdAt: "2025-05-10T11:15:00Z",
     updatedAt: "2025-05-11T09:45:00Z",
+  },
+];
+
+export const MOCK_MULTI_ASSET_RUNS: MultiAssetPayrollRun[] = [
+  {
+    id: "mar_001",
+    companyId: "company_001",
+    label: "Q3 2026 Multi-Asset Payroll — Engineering & Product",
+    createdAt: "2026-07-01T08:00:00Z",
+    executedAt: "2026-07-02T10:15:00Z",
+    status: "succeeded",
+    totalEmployees: 3,
+    proof: "0xzkproof_multiasset_001",
+    proofStatus: "ready",
+    assetGroups: [
+      {
+        asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+        employees: [
+          { employeeId: "emp_001", name: "Alice Mensah", address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37", amount: 3500, salaryCommitment: "0xabc123def456" },
+          { employeeId: "emp_002", name: "Kwame Asante", address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", amount: 3200, salaryCommitment: "0xdef789ghi012" },
+        ],
+        totalAmount: 6700,
+        transactionCount: 2,
+        status: "succeeded",
+        txHash: "abc123usdc_tx_001",
+        executedAt: "2026-07-02T10:15:00Z",
+        treasuryReadiness: { asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" }, requiredAmount: 6700, availableBalance: 12000, isFunded: true, shortfall: 0 },
+      },
+      {
+        asset: { code: "XLM" },
+        employees: [
+          { employeeId: "emp_004", name: "Kofi Boateng", address: "GCZJM2ZPKZM5LZPM2CZJM2ZPKZM5LZPM2CZJM2ZPKZM5LZPM2CZJM2", amount: 15000, salaryCommitment: "0xmno901pqr234" },
+        ],
+        totalAmount: 15000,
+        transactionCount: 1,
+        status: "succeeded",
+        txHash: "xlm_tx_001",
+        executedAt: "2026-07-02T10:16:00Z",
+        treasuryReadiness: { asset: { code: "XLM" }, requiredAmount: 15000, availableBalance: 45000, isFunded: true, shortfall: 0 },
+      },
+    ],
+  },
+  {
+    id: "mar_002",
+    companyId: "company_001",
+    label: "Q3 2026 Contractor Payroll — Mixed Assets",
+    createdAt: "2026-07-10T09:00:00Z",
+    status: "partial",
+    totalEmployees: 3,
+    proofStatus: "ready",
+    proof: "0xzkproof_multiasset_002",
+    assetGroups: [
+      {
+        asset: { code: "EURC", issuer: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP" },
+        employees: [
+          { employeeId: "emp_001", name: "Alice Mensah", address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37", amount: 2800, salaryCommitment: "0xabc123def456" },
+        ],
+        totalAmount: 2800,
+        transactionCount: 1,
+        status: "succeeded",
+        txHash: "eurc_tx_002",
+        executedAt: "2026-07-10T11:00:00Z",
+        treasuryReadiness: { asset: { code: "EURC", issuer: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP" }, requiredAmount: 2800, availableBalance: 5000, isFunded: true, shortfall: 0 },
+      },
+      {
+        asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+        employees: [
+          { employeeId: "emp_002", name: "Kwame Asante", address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", amount: 4500, salaryCommitment: "0xdef789ghi012" },
+          { employeeId: "emp_005", name: "Yaa Asantewaa", address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W38", amount: 3800, salaryCommitment: "0xstu456vwx789" },
+        ],
+        totalAmount: 8300,
+        transactionCount: 2,
+        status: "failed",
+        errorMessage: "Transaction rejected: insufficient trust line limit on receiving account",
+        treasuryReadiness: { asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" }, requiredAmount: 8300, availableBalance: 12000, isFunded: true, shortfall: 0 },
+      },
+    ],
+  },
+  {
+    id: "mar_003",
+    companyId: "company_001",
+    label: "August 2026 Payroll — Underfunded Draft",
+    createdAt: "2026-07-25T08:00:00Z",
+    status: "underfunded",
+    totalEmployees: 4,
+    proofStatus: "none",
+    assetGroups: [
+      {
+        asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+        employees: [
+          { employeeId: "emp_001", name: "Alice Mensah", address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37", amount: 3500, salaryCommitment: "0xabc123def456" },
+          { employeeId: "emp_002", name: "Kwame Asante", address: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", amount: 3200, salaryCommitment: "0xdef789ghi012" },
+        ],
+        totalAmount: 6700,
+        transactionCount: 2,
+        status: "funded",
+        treasuryReadiness: { asset: { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" }, requiredAmount: 6700, availableBalance: 12000, isFunded: true, shortfall: 0 },
+      },
+      {
+        asset: { code: "EURC", issuer: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP" },
+        employees: [
+          { employeeId: "emp_004", name: "Kofi Boateng", address: "GCZJM2ZPKZM5LZPM2CZJM2ZPKZM5LZPM2CZJM2ZPKZM5LZPM2CZJM2", amount: 4200, salaryCommitment: "0xmno901pqr234" },
+          { employeeId: "emp_005", name: "Yaa Asantewaa", address: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W38", amount: 3800, salaryCommitment: "0xstu456vwx789" },
+        ],
+        totalAmount: 8000,
+        transactionCount: 2,
+        status: "underfunded",
+        treasuryReadiness: { asset: { code: "EURC", issuer: "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP" }, requiredAmount: 8000, availableBalance: 3500, isFunded: false, shortfall: 4500 },
+      },
+    ],
   },
 ];

--- a/lib/payroll/multiAsset.ts
+++ b/lib/payroll/multiAsset.ts
@@ -1,0 +1,160 @@
+import type {
+  AssetGroup,
+  AssetGroupEmployee,
+  MultiAssetPayrollRun,
+  MultiAssetReconciliation,
+  ReconciliationEntry,
+  StellarAsset,
+  TreasuryReadiness,
+} from "@/types/models";
+
+/** Canonical display label for a Stellar asset. */
+export function assetLabel(asset: StellarAsset): string {
+  return asset.code === "XLM" && !asset.issuer ? "XLM (native)" : asset.code;
+}
+
+/** True when the asset is native Stellar lumens. */
+export function isNative(asset: StellarAsset): boolean {
+  return asset.code === "XLM" && !asset.issuer;
+}
+
+/**
+ * Group employees by their payment asset and compute per-group totals.
+ * Each employee is expected to have `assetCode`/`assetIssuer` on the
+ * extended employee record produced by the multi-asset planner.
+ */
+export function groupEmployeesByAsset(
+  employees: Array<AssetGroupEmployee & { assetCode: string; assetIssuer?: string }>,
+  treasuryBalances: Map<string, number>,
+): AssetGroup[] {
+  const byKey = new Map<string, Array<AssetGroupEmployee & { assetCode: string; assetIssuer?: string }>>();
+
+  for (const emp of employees) {
+    const key = emp.assetIssuer ? `${emp.assetCode}:${emp.assetIssuer}` : emp.assetCode;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key)!.push(emp);
+  }
+
+  return [...byKey.entries()].map(([_key, emps]) => {
+    const first = emps[0];
+    const asset: StellarAsset = { code: first.assetCode, issuer: first.assetIssuer };
+    const assetKey = asset.issuer ? `${asset.code}:${asset.issuer}` : asset.code;
+    const totalAmount = emps.reduce((s, e) => s + e.amount, 0);
+    const availableBalance = treasuryBalances.get(assetKey) ?? 0;
+    const isFunded = availableBalance >= totalAmount;
+
+    const treasuryReadiness: TreasuryReadiness = {
+      asset,
+      requiredAmount: totalAmount,
+      availableBalance,
+      isFunded,
+      shortfall: isFunded ? 0 : totalAmount - availableBalance,
+    };
+
+    return {
+      asset,
+      employees: emps.map((e) => ({
+        employeeId: e.employeeId,
+        name: e.name,
+        address: e.address,
+        amount: e.amount,
+        salaryCommitment: e.salaryCommitment,
+      })),
+      totalAmount,
+      transactionCount: emps.length,
+      status: isFunded ? "funded" : "underfunded",
+      treasuryReadiness,
+    } satisfies AssetGroup;
+  });
+}
+
+/** Overall run status derived from its asset groups. */
+export function deriveRunStatus(groups: AssetGroup[]): MultiAssetPayrollRun["status"] {
+  if (groups.length === 0) return "draft";
+  const statuses = new Set(groups.map((g) => g.status));
+
+  if (statuses.has("underfunded")) return "underfunded";
+  if (statuses.has("executing")) return "executing";
+
+  const allSucceeded = groups.every((g) => g.status === "succeeded");
+  if (allSucceeded) return "succeeded";
+
+  const anySucceeded = groups.some((g) => g.status === "succeeded");
+  const anyFailed = groups.some((g) => g.status === "failed");
+  if (anySucceeded && anyFailed) return "partial";
+  if (anyFailed) return "failed";
+
+  if (groups.every((g) => g.status === "funded")) return "ready";
+  return "draft";
+}
+
+/** Build a reconciliation summary for a completed (or partial) run. */
+export function buildReconciliation(run: MultiAssetPayrollRun): MultiAssetReconciliation {
+  const groups = run.assetGroups.map((group) => {
+    const entries: ReconciliationEntry[] = group.employees.map((emp) => {
+      const confirmed = group.status === "succeeded" ? emp.amount : 0;
+      return {
+        employeeId: emp.employeeId,
+        name: emp.name,
+        assetCode: group.asset.code,
+        expectedAmount: emp.amount,
+        confirmedAmount: confirmed,
+        status:
+          group.status === "succeeded"
+            ? "confirmed"
+            : group.status === "failed"
+            ? "missing"
+            : "discrepancy",
+        txHash: group.txHash,
+        confirmedAt: group.executedAt,
+      } satisfies ReconciliationEntry;
+    });
+
+    const totalConfirmed = entries.reduce((s, e) => s + e.confirmedAmount, 0);
+    const discrepancyCount = entries.filter((e) => e.status !== "confirmed").length;
+
+    return {
+      asset: group.asset,
+      status:
+        group.status === "succeeded"
+          ? "complete"
+          : group.status === "partial"
+          ? "partial"
+          : group.status === "failed"
+          ? "failed"
+          : "pending",
+      entries,
+      totalExpected: group.totalAmount,
+      totalConfirmed,
+      discrepancyCount,
+    } as MultiAssetReconciliation["groups"][number];
+  });
+
+  const canExportAudit = groups.every((g) => g.status === "complete" || g.status === "partial");
+
+  return {
+    runId: run.id,
+    generatedAt: new Date().toISOString(),
+    groups,
+    canExportAudit,
+  };
+}
+
+/** Format a Stellar stroops amount as a human-readable string. */
+export function formatAssetAmount(amount: number, assetCode: string): string {
+  return `${amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })} ${assetCode}`;
+}
+
+/** Risk label for a group's status. */
+export function groupRiskLabel(group: AssetGroup): string {
+  switch (group.status) {
+    case "underfunded":
+      return `Shortfall: ${formatAssetAmount(group.treasuryReadiness.shortfall, group.asset.code)}`;
+    case "failed":
+      return group.errorMessage ?? "Execution failed";
+    case "partial":
+      return "Partially executed";
+    default:
+      return "";
+  }
+}

--- a/types/models.ts
+++ b/types/models.ts
@@ -127,3 +127,98 @@ export interface AuditAccessRequest {
   updatedAt?: string;
   viewKeyId?: string;
 }
+
+// ── Multi-asset payroll orchestration ────────────────────────────────────────
+
+export type StellarAsset = {
+  code: string;
+  issuer?: string; // undefined for native XLM
+};
+
+export type AssetGroupStatus =
+  | "pending"
+  | "funded"
+  | "underfunded"
+  | "executing"
+  | "succeeded"
+  | "failed"
+  | "partial";
+
+export interface AssetGroupEmployee {
+  employeeId: string;
+  name: string;
+  address: string;
+  amount: number;
+  /** SHA-256 commitment of the salary — never expose the raw amount to unauthorized viewers */
+  salaryCommitment: string;
+}
+
+export interface TreasuryReadiness {
+  asset: StellarAsset;
+  requiredAmount: number;
+  availableBalance: number;
+  isFunded: boolean;
+  shortfall: number;
+}
+
+export interface AssetGroup {
+  asset: StellarAsset;
+  employees: AssetGroupEmployee[];
+  totalAmount: number;
+  transactionCount: number;
+  status: AssetGroupStatus;
+  txHash?: string;
+  errorMessage?: string;
+  executedAt?: string;
+  treasuryReadiness: TreasuryReadiness;
+}
+
+export type MultiAssetRunStatus =
+  | "draft"
+  | "ready"
+  | "underfunded"
+  | "executing"
+  | "succeeded"
+  | "partial"
+  | "failed";
+
+export interface MultiAssetPayrollRun {
+  id: string;
+  companyId: string;
+  label: string;
+  createdAt: string;
+  executedAt?: string;
+  status: MultiAssetRunStatus;
+  assetGroups: AssetGroup[];
+  totalEmployees: number;
+  /** Opaque ZK proof covering all groups */
+  proof?: string;
+  proofStatus: "none" | "generating" | "ready" | "expired";
+}
+
+export type ReconciliationGroupStatus = "complete" | "partial" | "failed" | "pending";
+
+export interface ReconciliationEntry {
+  employeeId: string;
+  name: string;
+  assetCode: string;
+  expectedAmount: number;
+  confirmedAmount: number;
+  status: "confirmed" | "discrepancy" | "missing";
+  txHash?: string;
+  confirmedAt?: string;
+}
+
+export interface MultiAssetReconciliation {
+  runId: string;
+  generatedAt: string;
+  groups: Array<{
+    asset: StellarAsset;
+    status: ReconciliationGroupStatus;
+    entries: ReconciliationEntry[];
+    totalExpected: number;
+    totalConfirmed: number;
+    discrepancyCount: number;
+  }>;
+  canExportAudit: boolean;
+}


### PR DESCRIPTION
Closes #175

## Summary

- **Per-asset grouping with treasury readiness checks** — employees are grouped by payment asset before submission. Each group shows a readiness bar comparing treasury balance to the required amount. Underfunded groups block submission with a clear shortfall warning.
- **Partial execution handling** — when one asset group succeeds and another fails, the run enters `partial` state. Failed groups display their error message and a per-group retry button that re-runs only the failed transactions, leaving confirmed ones untouched.
- **Reconciliation UI** — a dedicated page compares expected vs. confirmed amounts per employee and per asset, with a completion bar, discrepancy highlights, retry guidance, and CSV export for audit-ready runs.
- **ZK proof lifecycle surfaced** — proof status (none / generating / ready / expired) is shown at the run level; expired proofs are flagged before submission to prevent invalid runs.

## Files changed

| File | Purpose |
|------|---------|
| `types/models.ts` | New types: `StellarAsset`, `AssetGroup`, `AssetGroupEmployee`, `TreasuryReadiness`, `MultiAssetPayrollRun`, `MultiAssetReconciliation`, `ReconciliationEntry` |
| `lib/payroll/multiAsset.ts` | Pure helpers: `groupEmployeesByAsset`, `deriveRunStatus`, `buildReconciliation`, `formatAssetAmount`, `assetLabel`, `groupRiskLabel` |
| `lib/api/mockData.ts` | Three mock multi-asset runs covering succeeded, partial-failure, and underfunded states |
| `components/features/payroll/MultiAssetPayrollReview.tsx` | Collapsible per-asset group cards with treasury bar, employee list, proof status, submit/retry actions |
| `components/features/payroll/MultiAssetReconciliation.tsx` | Per-group reconciliation panels with discrepancy highlighting, completion bar, CSV export |
| `app/payroll/multi-asset/page.tsx` | Run list with per-run asset badges and underfunded warning banner |
| `app/payroll/multi-asset/[runId]/page.tsx` | Run detail page wired to review component with simulated execution |
| `app/payroll/multi-asset/[runId]/reconciliation/page.tsx` | Reconciliation page with CSV export handler |
| `__tests__/multi-asset-payroll.test.tsx` | 27 unit tests covering all library functions and edge cases |

## Test coverage

- Single-asset happy path
- Multi-asset funded run → ready status
- Partially funded run → underfunded status (blocks submission)
- Partial execution: confirmed entries vs. missing entries per group
- `canExportAudit` flag: true only when all groups settled
- `deriveRunStatus` all seven transitions: draft, ready, underfunded, executing, succeeded, partial, failed