### PR TITLE
feat(payroll): add payroll approval queue for executive review

### DIFF
--- a/__tests__/approval-queue.test.tsx
+++ b/__tests__/approval-queue.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, beforeEach } from "vitest";
+import { ExecutiveApprovalQueue } from "@/components/features/payroll/ExecutiveApprovalQueue";
+import { useApprovalQueueStore } from "@/stores/approvalQueue";
+
+describe("Executive Approval Queue (Issue #218)", () => {
+  beforeEach(() => {
+    useApprovalQueueStore.setState({
+      drafts: [
+        {
+          id: "draft_test_100",
+          companyId: "company_001",
+          timestamp: "2026-07-29T10:00:00Z",
+          createdAt: "2026-07-29T10:00:00Z",
+          totalAmount: 150000,
+          employeeCount: 10,
+          proof: "0xzkproof_test_100",
+          status: "pending",
+          approvalStatus: "pending_executive_approval",
+          requiresExecutiveReview: true,
+          employeeIds: ["emp_001"],
+          notes: "High-value Q3 bonus run",
+          approvalHistory: [],
+        },
+      ],
+    });
+  });
+
+  it("renders pending executive approval drafts", () => {
+    render(<ExecutiveApprovalQueue />);
+    expect(screen.getByText("Executive Approval Queue")).toBeInTheDocument();
+    expect(screen.getByText("draft_test_100")).toBeInTheDocument();
+    expect(screen.getByText("$150,000 USD")).toBeInTheDocument();
+  });
+
+  it("allows approving a payroll draft for signing", () => {
+    render(<ExecutiveApprovalQueue />);
+    const approveBtn = screen.getByText("Approve & Queue for Signing");
+    fireEvent.click(approveBtn);
+
+    const store = useApprovalQueueStore.getState();
+    const approvedDraft = store.drafts.find((d) => d.id === "draft_test_100");
+    expect(approvedDraft?.approvalStatus).toBe("approved");
+    expect(approvedDraft?.approvalHistory).toHaveLength(1);
+  });
+
+  it("allows rejecting a payroll draft", () => {
+    render(<ExecutiveApprovalQueue />);
+    const rejectBtn = screen.getByText("Reject Draft");
+    fireEvent.click(rejectBtn);
+
+    const store = useApprovalQueueStore.getState();
+    const rejectedDraft = store.drafts.find((d) => d.id === "draft_test_100");
+    expect(rejectedDraft?.approvalStatus).toBe("rejected");
+    expect(rejectedDraft?.status).toBe("cancelled");
+  });
+});

--- a/app/payroll/approvals/page.tsx
+++ b/app/payroll/approvals/page.tsx
@@ -1,0 +1,10 @@
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import { ExecutiveApprovalQueue } from "@/components/features/payroll/ExecutiveApprovalQueue";
+
+export default function PayrollApprovalsPage() {
+  return (
+    <DashboardLayout>
+      <ExecutiveApprovalQueue />
+    </DashboardLayout>
+  );
+}

--- a/components/features/payroll/ExecutiveApprovalQueue.tsx
+++ b/components/features/payroll/ExecutiveApprovalQueue.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { useApprovalQueueStore, type ApprovalDraft } from "@/stores/approvalQueue";
+import { StatusBadge } from "@/components/ui/StatusBadge";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, XCircle, AlertTriangle, ShieldCheck, FileText, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+export function ExecutiveApprovalQueue() {
+  const { drafts, approveDraft, rejectDraft } = useApprovalQueueStore();
+  const [filter, setFilter] = useState<"pending" | "approved" | "rejected" | "all">("pending");
+  const [selectedDraft, setSelectedDraft] = useState<ApprovalDraft | null>(null);
+  const [comment, setComment] = useState("");
+
+  const filteredDrafts = drafts.filter((d) => {
+    if (filter === "pending") return d.approvalStatus === "pending_executive_approval";
+    if (filter === "approved") return d.approvalStatus === "approved";
+    if (filter === "rejected") return d.approvalStatus === "rejected";
+    return true;
+  });
+
+  const pendingCount = drafts.filter((d) => d.approvalStatus === "pending_executive_approval").length;
+
+  const handleApprove = (draft: ApprovalDraft) => {
+    approveDraft(draft.id, "Executive Admin", "Admin", comment || "Approved for execution");
+    setSelectedDraft(null);
+    setComment("");
+  };
+
+  const handleReject = (draft: ApprovalDraft) => {
+    rejectDraft(draft.id, "Executive Admin", "Admin", comment || "Rejected during executive review");
+    setSelectedDraft(null);
+    setComment("");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 border-b pb-5">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <ShieldCheck className="h-6 w-6 text-indigo-600" />
+            Executive Approval Queue
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Review and authorize high-value payroll drafts prior to cryptographic signing and network dispatch.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 bg-indigo-50 border border-indigo-200 px-3 py-1.5 rounded-lg text-sm text-indigo-800">
+          <AlertTriangle className="h-4 w-4 text-indigo-600" />
+          <span className="font-semibold">{pendingCount}</span> draft(s) awaiting review
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 border-b pb-2">
+        <button
+          onClick={() => setFilter("pending")}
+          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            filter === "pending"
+              ? "bg-indigo-600 text-white"
+              : "text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          Pending Review ({pendingCount})
+        </button>
+        <button
+          onClick={() => setFilter("approved")}
+          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            filter === "approved"
+              ? "bg-green-600 text-white"
+              : "text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          Approved
+        </button>
+        <button
+          onClick={() => setFilter("rejected")}
+          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            filter === "rejected"
+              ? "bg-red-600 text-white"
+              : "text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          Rejected
+        </button>
+        <button
+          onClick={() => setFilter("all")}
+          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            filter === "all"
+              ? "bg-gray-800 text-white"
+              : "text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          All ({drafts.length})
+        </button>
+      </div>
+
+      {filteredDrafts.length === 0 ? (
+        <div className="text-center py-12 bg-gray-50 border border-dashed rounded-xl">
+          <CheckCircle2 className="h-10 w-10 text-gray-400 mx-auto mb-3" />
+          <h3 className="text-base font-semibold text-gray-900">No payroll drafts in this queue</h3>
+          <p className="text-sm text-gray-500 max-w-md mx-auto mt-1">
+            All submitted high-value payroll runs have been reviewed or processed.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4">
+          {filteredDrafts.map((draft) => (
+            <div
+              key={draft.id}
+              className="bg-white border rounded-xl p-5 shadow-sm hover:shadow-md transition-shadow space-y-4"
+            >
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3">
+                <div>
+                  <div className="flex items-center gap-3">
+                    <span className="font-mono text-sm font-semibold text-indigo-600">{draft.id}</span>
+                    <StatusBadge
+                      status={
+                        draft.approvalStatus === "approved"
+                          ? "verified"
+                          : draft.approvalStatus === "rejected"
+                          ? "failed"
+                          : "pending"
+                      }
+                      customLabel={
+                        draft.approvalStatus === "pending_executive_approval"
+                          ? "Executive Review Required"
+                          : draft.approvalStatus === "approved"
+                          ? "Approved for Signing"
+                          : "Rejected"
+                      }
+                    />
+                  </div>
+                  {draft.notes && <p className="text-sm text-gray-700 mt-1 font-medium">{draft.notes}</p>}
+                </div>
+                <div className="text-right">
+                  <div className="text-xl font-bold text-gray-900">
+                    ${draft.totalAmount.toLocaleString()} USD
+                  </div>
+                  <div className="text-xs text-gray-500">{draft.employeeCount} Employees</div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs bg-gray-50 p-3 rounded-lg border text-gray-600">
+                <div>
+                  <span className="font-semibold text-gray-700">Created:</span>{" "}
+                  {new Date(draft.createdAt).toLocaleString()}
+                </div>
+                <div>
+                  <span className="font-semibold text-gray-700">ZK Proof:</span>{" "}
+                  <span className="font-mono">{draft.proof ? "Generated (Verified)" : "Pending"}</span>
+                </div>
+                <div>
+                  <span className="font-semibold text-gray-700">Company ID:</span> {draft.companyId}
+                </div>
+              </div>
+
+              {draft.approvalHistory && draft.approvalHistory.length > 0 && (
+                <div className="border-t pt-3 space-y-1">
+                  <h4 className="text-xs font-semibold text-gray-700">Review History:</h4>
+                  {draft.approvalHistory.map((hist, idx) => (
+                    <div key={idx} className="text-xs text-gray-600 flex justify-between">
+                      <span>
+                        <strong>{hist.approvedBy}</strong> ({hist.role}): {hist.comment}
+                      </span>
+                      <span className="text-gray-400">{new Date(hist.approvedAt).toLocaleTimeString()}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {draft.approvalStatus === "pending_executive_approval" && (
+                <div className="flex flex-col sm:flex-row items-center justify-between gap-3 border-t pt-3">
+                  <input
+                    type="text"
+                    placeholder="Add executive review notes/comment (optional)..."
+                    value={selectedDraft?.id === draft.id ? comment : ""}
+                    onChange={(e) => {
+                      setSelectedDraft(draft);
+                      setComment(e.target.value);
+                    }}
+                    className="w-full sm:w-2/3 px-3 py-1.5 text-xs border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-red-600 border-red-200 hover:bg-red-50 text-xs"
+                      onClick={() => handleReject(draft)}
+                    >
+                      <XCircle className="h-4 w-4 mr-1" />
+                      Reject Draft
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="bg-indigo-600 hover:bg-indigo-700 text-white text-xs"
+                      onClick={() => handleApprove(draft)}
+                    >
+                      <CheckCircle2 className="h-4 w-4 mr-1" />
+                      Approve & Queue for Signing
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {draft.approvalStatus === "approved" && (
+                <div className="flex justify-end border-t pt-3">
+                  <Link href="/payroll/execute">
+                    <Button size="sm" variant="outline" className="text-xs text-indigo-600 border-indigo-200">
+                      Proceed to Payroll Execution Wizard
+                      <ArrowRight className="h-3.5 w-3.5 ml-1" />
+                    </Button>
+                  </Link>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -33,6 +33,12 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
     disabledReason: { operator: 'Employee roster changes require admin approval.' },
   },
   {
+    label: 'Approval Queue',
+    href: '/payroll/approvals',
+    icon: 'clipboard',
+    roles: ['admin', 'operator'],
+  },
+  {
     label: 'Execute Payroll',
     href: '/payroll/execute',
     icon: 'play',
@@ -87,6 +93,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
 export const ROUTE_ROLE_RULES: Array<{ prefix: string; roles: UserRole[] }> = [
   { prefix: '/employees/add', roles: ['admin'] },
   { prefix: '/employees', roles: ['admin', 'operator'] },
+  { prefix: '/payroll/approvals', roles: ['admin', 'operator'] },
   { prefix: '/payroll/execute', roles: ['admin', 'operator'] },
   { prefix: '/payroll/run', roles: ['admin'] },
   { prefix: '/payroll/exceptions', roles: ['admin', 'operator', 'auditor'] },

--- a/stores/approvalQueue.ts
+++ b/stores/approvalQueue.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PayrollRun } from "@/types/models";
+
+export interface ApprovalDraft extends PayrollRun {
+  approvalStatus: "pending_executive_approval" | "approved" | "rejected";
+  requiresExecutiveReview: boolean;
+  notes?: string;
+}
+
+interface ApprovalQueueState {
+  drafts: ApprovalDraft[];
+  approveDraft: (id: string, reviewerName: string, role: string, comment?: string) => void;
+  rejectDraft: (id: string, reviewerName: string, role: string, comment?: string) => void;
+  addDraftForApproval: (draft: PayrollRun, notes?: string) => void;
+}
+
+const INITIAL_APPROVAL_DRAFTS: ApprovalDraft[] = [
+  {
+    id: "draft_exec_001",
+    companyId: "company_001",
+    timestamp: "2026-07-29T10:00:00Z",
+    createdAt: "2026-07-29T10:00:00Z",
+    totalAmount: 145000,
+    employeeCount: 18,
+    proof: "0xzkproof_exec_145k",
+    status: "pending",
+    approvalStatus: "pending_executive_approval",
+    requiresExecutiveReview: true,
+    employeeIds: ["emp_001", "emp_002", "emp_003", "emp_004", "emp_005"],
+    executedAt: null,
+    transactionHash: null,
+    notes: "Q3 Executive bonus & high-value engineering payroll run ($145,000)",
+    approvalHistory: [],
+  },
+  {
+    id: "draft_exec_002",
+    companyId: "company_001",
+    timestamp: "2026-07-28T14:30:00Z",
+    createdAt: "2026-07-28T14:30:00Z",
+    totalAmount: 88000,
+    employeeCount: 12,
+    proof: "0xzkproof_exec_88k",
+    status: "pending",
+    approvalStatus: "pending_executive_approval",
+    requiresExecutiveReview: true,
+    employeeIds: ["emp_001", "emp_002"],
+    executedAt: null,
+    transactionHash: null,
+    notes: "Mid-year operational expansion payroll batch",
+    approvalHistory: [],
+  },
+];
+
+export const useApprovalQueueStore = create<ApprovalQueueState>()(
+  persist(
+    (set) => ({
+      drafts: INITIAL_APPROVAL_DRAFTS,
+      approveDraft: (id, reviewerName, role, comment) =>
+        set((state) => ({
+          drafts: state.drafts.map((d) =>
+            d.id === id
+              ? {
+                  ...d,
+                  approvalStatus: "approved",
+                  status: "pending",
+                  approvalHistory: [
+                    ...(d.approvalHistory || []),
+                    {
+                      approvedBy: reviewerName,
+                      approvedAt: new Date().toISOString(),
+                      role,
+                      comment,
+                    },
+                  ],
+                }
+              : d,
+          ),
+        })),
+      rejectDraft: (id, reviewerName, role, comment) =>
+        set((state) => ({
+          drafts: state.drafts.map((d) =>
+            d.id === id
+              ? {
+                  ...d,
+                  approvalStatus: "rejected",
+                  status: "cancelled",
+                  approvalHistory: [
+                    ...(d.approvalHistory || []),
+                    {
+                      approvedBy: reviewerName,
+                      approvedAt: new Date().toISOString(),
+                      role,
+                      comment,
+                    },
+                  ],
+                }
+              : d,
+          ),
+        })),
+      addDraftForApproval: (draft, notes) =>
+        set((state) => ({
+          drafts: [
+            ...state.drafts,
+            {
+              ...draft,
+              approvalStatus: "pending_executive_approval",
+              requiresExecutiveReview: true,
+              notes,
+              approvalHistory: [],
+            },
+          ],
+        })),
+    }),
+    {
+      name: "zk_approval_queue_store",
+    },
+  ),
+);

--- a/types/models.ts
+++ b/types/models.ts
@@ -41,6 +41,13 @@ export interface PayrollTransaction {
   employeeCount: number;
   proof: string;
   status: "pending" | "verified" | "failed" | "cancelled";
+  approvalStatus?: "draft" | "pending_executive_approval" | "approved" | "rejected";
+  approvalHistory?: Array<{
+    approvedBy: string;
+    approvedAt: string;
+    role: string;
+    comment?: string;
+  }>;
   txHash?: string;
   isArchived?: boolean;
 }


### PR DESCRIPTION
## Description
This pull request implements an executive approval queue for high-value payroll runs prior to cryptographic signing and network dispatch.

1. **Executive Approval Queue Component & Page Route**:
   - Created `ExecutiveApprovalQueue` (`components/features/payroll/ExecutiveApprovalQueue.tsx`) and page route `/payroll/approvals` (`app/payroll/approvals/page.tsx`).
   - Surfaces high-value payroll drafts needing executive review with filtering (Pending, Approved, Rejected, All), review comments, and approval status badges.

2. **Approval Queue State Store**:
   - Created Zustand store `useApprovalQueueStore` (`stores/approvalQueue.ts`) for persisting draft status updates and review audit logs (`approvalHistory`).

3. **Navigation & Role-Based Rules**:
   - Added `Approval Queue` to navigation items and route role rules in `lib/auth/roles.ts` for Admin and Operator access.

4. **Testing**:
   - Added unit test suite in `__tests__/approval-queue.test.tsx` covering draft rendering, approval, and rejection actions.

Closes #218