### PR TITLE
feat: add payroll exception triage dashboard

### DIFF
--- a/__tests__/payroll-exceptions.test.tsx
+++ b/__tests__/payroll-exceptions.test.tsx
@@ -1,52 +1,93 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import PayrollExceptionsQueue from '@/components/features/payroll/PayrollExceptionsQueue';
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PayrollExceptionsQueue, {
+  type PayrollExceptionItem,
+} from "@/components/features/payroll/PayrollExceptionsQueue";
 
-describe('PayrollExceptionsQueue', () => {
-  it('renders the section heading', () => {
-    render(<PayrollExceptionsQueue />);
+const TRIAGE_ITEMS: PayrollExceptionItem[] = [
+  {
+    id: "exc_blocking",
+    runId: "run_blocking",
+    title: "Settlement failed on trust line limit",
+    summary: "A reconciliation error blocked the run.",
+    source: "reconciliation",
+    severity: "blocking",
+    status: "in_review",
+    nextAction: "Increase the receiving trust line limit and retry settlement.",
+    redactedValueLabel: "Settlement amount redacted",
+    createdAt: "2026-07-10T11:00:00Z",
+  },
+  {
+    id: "exc_warning",
+    runId: "run_warning",
+    title: "Proof generation pending",
+    summary: "The payroll batch is waiting on proof generation.",
+    source: "payroll-engine",
+    severity: "warning",
+    status: "open",
+    nextAction: "Generate the ZK proof and resubmit the run.",
+    redactedValueLabel: "Payroll amount redacted",
+    createdAt: "2026-07-12T11:00:00Z",
+  },
+  {
+    id: "exc_info",
+    runId: "run_info",
+    title: "Payroll run cancelled after review",
+    summary: "The run was intentionally cancelled.",
+    source: "compliance",
+    severity: "info",
+    status: "resolved",
+    nextAction: "No action required.",
+    redactedValueLabel: "Sensitive run details hidden",
+    createdAt: "2026-07-13T11:00:00Z",
+  },
+];
+
+describe("PayrollExceptionsQueue", () => {
+  it("renders grouped severity sections with redaction copy", () => {
+    render(<PayrollExceptionsQueue exceptions={TRIAGE_ITEMS} />);
+
     expect(
-      screen.getByRole('region', { name: /payroll exceptions/i }),
+      screen.getByRole("region", { name: /payroll exception triage/i }),
     ).toBeInTheDocument();
+    expect(screen.getByText(/sensitive payroll values stay redacted/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("table").length).toBe(3);
+    expect(screen.getByText(/settlement amount redacted/i)).toBeInTheDocument();
   });
 
-  it('renders exception items from mock data', () => {
-    render(<PayrollExceptionsQueue />);
-    // At least one pending/failed tx from MOCK_TRANSACTIONS
-    const items = screen.queryAllByRole('listitem');
-    expect(items.length).toBeGreaterThan(0);
+  it("filters by severity", async () => {
+    const user = userEvent.setup();
+    render(<PayrollExceptionsQueue exceptions={TRIAGE_ITEMS} />);
+
+    await user.selectOptions(screen.getByLabelText(/filter by severity/i), "warning");
+
+    expect(screen.getAllByRole("table")).toHaveLength(1);
+    expect(screen.getByText(/proof generation pending/i)).toBeInTheDocument();
+    expect(screen.queryByText(/settlement failed on trust line limit/i)).not.toBeInTheDocument();
   });
 
-  it('shows reason code for each exception', () => {
-    render(<PayrollExceptionsQueue />);
-    expect(screen.getAllByText(/reason:/i).length).toBeGreaterThan(0);
+  it("filters by source and status", async () => {
+    const user = userEvent.setup();
+    render(<PayrollExceptionsQueue exceptions={TRIAGE_ITEMS} />);
+
+    await user.selectOptions(screen.getByLabelText(/filter by source/i), "compliance");
+    await user.selectOptions(screen.getByLabelText(/filter by status/i), "resolved");
+
+    const table = screen.getAllByRole("table")[0];
+    expect(screen.getAllByRole("table")).toHaveLength(1);
+    expect(within(table).getByText(/sensitive run details hidden/i)).toBeInTheDocument();
+    expect(within(table).getByText(/no action required/i)).toBeInTheDocument();
+    expect(screen.queryByText(/generate the zk proof/i)).not.toBeInTheDocument();
   });
 
-  it('shows next step for each exception', () => {
-    render(<PayrollExceptionsQueue />);
-    expect(screen.getAllByText(/payroll wizard/i).length).toBeGreaterThan(0);
-  });
+  it("renders an empty state when there are no exceptions", () => {
+    render(<PayrollExceptionsQueue exceptions={[]} />);
 
-  it('shows pending badge for pending transactions', () => {
-    render(<PayrollExceptionsQueue />);
-    expect(screen.getAllByText(/pending/i).length).toBeGreaterThan(0);
-  });
-
-  it('shows count badge in heading', () => {
-    render(<PayrollExceptionsQueue />);
-    const badge = screen.getByText(/^\d+$/);
-    expect(Number(badge.textContent)).toBeGreaterThan(0);
-  });
-
-  it('renders link to payroll wizard for each item', () => {
-    render(<PayrollExceptionsQueue />);
-    const links = screen.getAllByRole('link', { name: /go to payroll wizard/i });
-    expect(links.length).toBeGreaterThan(0);
-    links.forEach((l) => expect(l).toHaveAttribute('href', '/payroll'));
-  });
-
-  it('renders exception list with accessible label', () => {
-    render(<PayrollExceptionsQueue />);
-    expect(screen.getByRole('list', { name: /exceptions queue/i })).toBeInTheDocument();
+    expect(screen.getByText(/no payroll exceptions to triage/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open payroll/i })).toHaveAttribute(
+      "href",
+      "/payroll",
+    );
   });
 });

--- a/components/features/payroll/PayrollExceptionsQueue.tsx
+++ b/components/features/payroll/PayrollExceptionsQueue.tsx
@@ -1,137 +1,403 @@
 "use client";
 
-import { useMemo } from "react";
-import { AlertCircle, Clock, XCircle, ArrowRight } from "lucide-react";
-import { MOCK_TRANSACTIONS, MOCK_EMPLOYEES } from "@/lib/api/mockData";
-import type { PayrollTransaction } from "@/types";
+import { useMemo, useState, type ElementType } from "react";
+import {
+  AlertTriangle,
+  Info,
+  Search,
+  ShieldAlert,
+  SlidersHorizontal,
+} from "lucide-react";
+import Link from "next/link";
+import {
+  MOCK_MULTI_ASSET_RUNS,
+  MOCK_TRANSACTIONS,
+} from "@/lib/api/mockData";
+import EmptyState from "@/components/ui/EmptyState";
+import StatusBadge from "@/components/ui/StatusBadge";
 
-type ExceptionItem = {
-  tx: PayrollTransaction;
-  employeeNames: string[];
-  reasonCode: string;
-  nextStep: string;
+export type ExceptionSeverity = "blocking" | "warning" | "info";
+export type ExceptionSource = "payroll-engine" | "reconciliation" | "compliance";
+export type ExceptionStatus = "open" | "in_review" | "resolved";
+
+export interface PayrollExceptionItem {
+  id: string;
+  runId: string;
+  title: string;
+  summary: string;
+  source: ExceptionSource;
+  severity: ExceptionSeverity;
+  status: ExceptionStatus;
+  nextAction: string;
+  redactedValueLabel: string;
+  createdAt: string;
+}
+
+interface PayrollExceptionsQueueProps {
+  exceptions?: PayrollExceptionItem[];
+}
+
+const SEVERITY_ORDER: ExceptionSeverity[] = ["blocking", "warning", "info"];
+
+const SEVERITY_META: Record<
+  ExceptionSeverity,
+  { label: string; description: string; icon: ElementType; className: string }
+> = {
+  blocking: {
+    label: "Blocking",
+    description: "Issues that stop payroll from continuing safely.",
+    icon: AlertTriangle,
+    className: "border-red-200 bg-red-50 text-red-700",
+  },
+  warning: {
+    label: "Warning",
+    description: "Issues that need review before the next payroll step.",
+    icon: ShieldAlert,
+    className: "border-amber-200 bg-amber-50 text-amber-700",
+  },
+  info: {
+    label: "Info",
+    description: "Informational notices that do not require immediate action.",
+    icon: Info,
+    className: "border-sky-200 bg-sky-50 text-sky-700",
+  },
 };
 
-const REASON_CODES: Record<PayrollTransaction["status"], string> = {
-  pending: "Awaiting ZK proof generation",
-  failed: "Transaction submission failed",
-  verified: "",
-  cancelled: "Transaction was cancelled by user",
+const SOURCE_LABELS: Record<ExceptionSource, string> = {
+  "payroll-engine": "Payroll engine",
+  reconciliation: "Reconciliation",
+  compliance: "Compliance",
 };
 
-const NEXT_STEPS: Record<PayrollTransaction["status"], string> = {
-  pending: "Trigger proof generation or check wallet connectivity",
-  failed: "Review transaction hash and retry via payroll wizard",
-  verified: "",
-  cancelled: "No further action needed",
-};
+const STATUS_OPTIONS: Array<ExceptionStatus | "all"> = [
+  "all",
+  "open",
+  "in_review",
+  "resolved",
+];
 
-const STATUS_ICONS: Record<string, React.ElementType> = {
-  pending: Clock,
-  failed: XCircle,
-};
+function buildDefaultExceptions(): PayrollExceptionItem[] {
+  const pendingRun = MOCK_TRANSACTIONS.find((tx) => tx.status === "pending");
+  const cancelledRun = MOCK_TRANSACTIONS.find((tx) => tx.status === "cancelled");
+  const failedMultiAssetRun = MOCK_MULTI_ASSET_RUNS.find((run) => run.status === "failed");
 
-const STATUS_CLASSES: Record<string, string> = {
-  pending: "text-yellow-600",
-  failed: "text-red-600",
-};
+  return [
+    pendingRun
+      ? {
+          id: pendingRun.id,
+          runId: pendingRun.id,
+          title: "Proof generation pending",
+          summary: "The payroll batch is waiting on proof generation before submission.",
+          source: "payroll-engine",
+          severity: "warning",
+          status: "open",
+          nextAction: "Generate the ZK proof and resubmit the run.",
+          redactedValueLabel: "Payroll amount redacted",
+          createdAt: pendingRun.createdAt,
+        }
+      : null,
+    failedMultiAssetRun
+      ? {
+          id: failedMultiAssetRun.id,
+          runId: failedMultiAssetRun.id,
+          title: "Trust line limit blocked settlement",
+          summary:
+            failedMultiAssetRun.assetGroups[1]?.errorMessage ??
+            "A reconciliation error blocked the multi-asset payroll run.",
+          source: "reconciliation",
+          severity: "blocking",
+          status: "in_review",
+          nextAction: "Increase the receiving trust line limit and retry settlement.",
+          redactedValueLabel: "Settlement amount redacted",
+          createdAt: failedMultiAssetRun.createdAt,
+        }
+      : null,
+    cancelledRun
+      ? {
+          id: cancelledRun.id,
+          runId: cancelledRun.id,
+          title: "Payroll run cancelled after review",
+          summary: "The run was intentionally cancelled and requires no follow-up.",
+          source: "compliance",
+          severity: "info",
+          status: "resolved",
+          nextAction: "No action required.",
+          redactedValueLabel: "Sensitive run details hidden",
+          createdAt: cancelledRun.createdAt,
+        }
+      : null,
+  ].filter(Boolean) as PayrollExceptionItem[];
+}
 
-export default function PayrollExceptionsQueue() {
-  const exceptions = useMemo<ExceptionItem[]>(() => {
-    return MOCK_TRANSACTIONS.filter(
-      (tx) => tx.status === "pending" || tx.status === "failed",
-    ).map((tx) => ({
-      tx,
-      employeeNames: MOCK_EMPLOYEES.slice(0, tx.employeeCount).map((e) => e.name),
-      reasonCode: REASON_CODES[tx.status],
-      nextStep: NEXT_STEPS[tx.status],
-    }));
-  }, []);
+function severityIcon(severity: ExceptionSeverity) {
+  const Icon = SEVERITY_META[severity].icon;
+  return <Icon className="h-4 w-4" aria-hidden />;
+}
+
+function filterLabel(value: string) {
+  return value.replace(/[-_]/g, " ");
+}
+
+export default function PayrollExceptionsQueue({
+  exceptions = buildDefaultExceptions(),
+}: PayrollExceptionsQueueProps) {
+  const [severityFilter, setSeverityFilter] = useState<ExceptionSeverity | "all">("all");
+  const [sourceFilter, setSourceFilter] = useState<ExceptionSource | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<ExceptionStatus | "all">("all");
+
+  const filtered = useMemo(
+    () =>
+      exceptions.filter((item) => {
+        if (severityFilter !== "all" && item.severity !== severityFilter) {
+          return false;
+        }
+        if (sourceFilter !== "all" && item.source !== sourceFilter) {
+          return false;
+        }
+        if (statusFilter !== "all" && item.status !== statusFilter) {
+          return false;
+        }
+        return true;
+      }),
+    [exceptions, severityFilter, sourceFilter, statusFilter],
+  );
+
+  const grouped = useMemo(
+    () =>
+      SEVERITY_ORDER.map((severity) => ({
+        severity,
+        items: filtered.filter((item) => item.severity === severity),
+      })).filter((group) => group.items.length > 0),
+    [filtered],
+  );
+
+  const counts = useMemo(
+    () =>
+      SEVERITY_ORDER.reduce(
+        (acc, severity) => {
+          acc[severity] = exceptions.filter((item) => item.severity === severity).length;
+          return acc;
+        },
+        { blocking: 0, warning: 0, info: 0 } as Record<ExceptionSeverity, number>,
+      ),
+    [exceptions],
+  );
+
+  const hasFilters =
+    severityFilter !== "all" || sourceFilter !== "all" || statusFilter !== "all";
 
   if (exceptions.length === 0) {
     return (
-      <section
-        aria-labelledby="exceptions-heading"
-        className="rounded-lg bg-white p-6 shadow-sm"
-      >
+      <section aria-labelledby="exceptions-heading" className="rounded-lg bg-white p-6 shadow-sm">
         <h2 id="exceptions-heading" className="text-base font-semibold text-gray-900">
-          Payroll exceptions
+          Payroll exception triage
         </h2>
-        <p className="mt-3 text-sm text-gray-500">No exceptions — all payroll items are clear.</p>
+        <EmptyState
+          title="No payroll exceptions to triage"
+          description="Admins will see blocking errors, warnings, and informational notices here once payroll runs surface issues."
+          action={{ label: "Open payroll", href: "/payroll" }}
+        />
       </section>
     );
   }
 
   return (
     <section aria-labelledby="exceptions-heading" className="rounded-lg bg-white p-6 shadow-sm">
-      <h2 id="exceptions-heading" className="mb-4 text-base font-semibold text-gray-900">
-        Payroll exceptions{" "}
-        <span className="ml-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
-          {exceptions.length}
-        </span>
-      </h2>
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 id="exceptions-heading" className="text-base font-semibold text-gray-900">
+            Payroll exception triage
+          </h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Group payroll failures by severity, source, and next action while keeping
+            sensitive values redacted.
+          </p>
+        </div>
 
-      <ul className="space-y-3" aria-label="exceptions queue">
-        {exceptions.map(({ tx, employeeNames, reasonCode, nextStep }) => {
-          const Icon = STATUS_ICONS[tx.status] ?? AlertCircle;
-          const colorClass = STATUS_CLASSES[tx.status] ?? "text-gray-600";
-
-          return (
-            <li
-              key={tx.id}
-              className="flex flex-col gap-2 rounded-lg border border-gray-200 p-4"
-            >
-              <div className="flex items-start gap-3">
-                <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} aria-hidden />
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-sm font-medium text-gray-900">
-                      Payroll run {tx.id}
-                    </span>
-                    <span
-                      className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${
-                        tx.status === "failed"
-                          ? "bg-red-100 text-red-700"
-                          : "bg-yellow-100 text-yellow-700"
-                      }`}
-                    >
-                      {tx.status}
-                    </span>
-                  </div>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    ${tx.totalAmount.toLocaleString()} · {tx.employeeCount} employee(s) ·{" "}
-                    {new Date(tx.timestamp).toLocaleDateString()}
-                  </p>
-                  {employeeNames.length > 0 && (
-                    <p className="mt-1 text-xs text-gray-500">
-                      {employeeNames.join(", ")}
-                    </p>
-                  )}
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          {SEVERITY_ORDER.map((severity) => {
+            const meta = SEVERITY_META[severity];
+            return (
+              <div key={severity} className={`rounded-lg border px-3 py-2 ${meta.className}`}>
+                <div className="flex items-center gap-1 font-semibold">
+                  {severityIcon(severity)}
+                  <span>{meta.label}</span>
                 </div>
+                <p className="mt-1 text-[11px] opacity-80">{counts[severity]} total</p>
               </div>
+            );
+          })}
+        </div>
+      </div>
 
-              <div className="ml-7 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-700">
-                <span className="font-medium">Reason: </span>
-                {reasonCode}
-              </div>
+      <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-medium text-gray-900">
+          <SlidersHorizontal className="h-4 w-4 text-gray-500" aria-hidden />
+          Filters
+        </div>
 
-              <div className="ml-7 flex items-center gap-1 text-xs text-indigo-600">
-                <ArrowRight className="h-3 w-3" aria-hidden />
-                <span>{nextStep}</span>
-              </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-sm">
+            <span className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Severity
+            </span>
+            <select
+              aria-label="Filter by severity"
+              value={severityFilter}
+              onChange={(event) =>
+                setSeverityFilter(event.target.value as ExceptionSeverity | "all")
+              }
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">All severities</option>
+              <option value="blocking">Blocking</option>
+              <option value="warning">Warning</option>
+              <option value="info">Info</option>
+            </select>
+          </label>
 
-              <div className="ml-7">
-                <a
-                  href="/payroll"
-                  className="text-xs font-medium text-indigo-600 hover:underline"
-                >
-                  Go to payroll wizard →
-                </a>
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+          <label className="space-y-1 text-sm">
+            <span className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Source
+            </span>
+            <select
+              aria-label="Filter by source"
+              value={sourceFilter}
+              onChange={(event) =>
+                setSourceFilter(event.target.value as ExceptionSource | "all")
+              }
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="all">All sources</option>
+              <option value="payroll-engine">Payroll engine</option>
+              <option value="reconciliation">Reconciliation</option>
+              <option value="compliance">Compliance</option>
+            </select>
+          </label>
+
+          <label className="space-y-1 text-sm">
+            <span className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Status
+            </span>
+            <select
+              aria-label="Filter by status"
+              value={statusFilter}
+              onChange={(event) =>
+                setStatusFilter(event.target.value as ExceptionStatus | "all")
+              }
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              {STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {status === "all" ? "All statuses" : filterLabel(status)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-6">
+          <div className="flex items-start gap-3">
+            <Search className="mt-0.5 h-4 w-4 text-gray-400" aria-hidden />
+            <div>
+              <p className="text-sm font-medium text-gray-900">
+                No exceptions match the current filters
+              </p>
+              <p className="mt-1 text-sm text-gray-500">
+                Clear one or more filters to see additional triage items.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {grouped.map((group) => {
+            const meta = SEVERITY_META[group.severity];
+            return (
+              <section key={group.severity} className="rounded-lg border border-gray-200">
+                <div className={`flex items-start justify-between gap-3 border-b px-4 py-3 ${meta.className}`}>
+                  <div>
+                    <h3 className="flex items-center gap-2 text-sm font-semibold">
+                      {severityIcon(group.severity)}
+                      {meta.label}
+                      <span className="rounded-full bg-white/80 px-2 py-0.5 text-xs font-medium">
+                        {group.items.length}
+                      </span>
+                    </h3>
+                    <p className="mt-1 text-xs opacity-80">{meta.description}</p>
+                  </div>
+                  <p className="text-xs font-medium uppercase tracking-wide opacity-80">
+                    {group.severity} queue
+                  </p>
+                </div>
+
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200" aria-label={`${meta.label} exceptions`}>
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Source
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Status
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Required next action
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Redaction
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 bg-white">
+                      {group.items.map((item) => (
+                        <tr key={item.id}>
+                          <td className="px-4 py-3 align-top">
+                            <div className="min-w-0">
+                              <p className="text-sm font-medium text-gray-900">{SOURCE_LABELS[item.source]}</p>
+                              <p className="mt-1 text-xs text-gray-500">{item.title}</p>
+                              <p className="mt-1 text-[11px] text-gray-400">Run {item.runId}</p>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 align-top">
+                            <div className="flex flex-col gap-2">
+                              <StatusBadge status={item.status} />
+                              <span className="inline-flex w-fit rounded-full border px-2 py-0.5 text-xs font-medium capitalize text-gray-600">
+                                {item.status === "in_review" ? "In review" : item.status}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 align-top">
+                            <p className="text-sm text-gray-700">{item.nextAction}</p>
+                            <p className="mt-1 text-xs text-gray-500">{item.summary}</p>
+                          </td>
+                          <td className="px-4 py-3 align-top">
+                            <p className="text-sm text-gray-700">{item.redactedValueLabel}</p>
+                            <p className="mt-1 text-xs text-gray-400">
+                              Updated {new Date(item.createdAt).toLocaleDateString()}
+                            </p>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between gap-3 rounded-lg bg-gray-50 px-4 py-3 text-xs text-gray-600">
+        <p>
+          Sensitive payroll values stay redacted in this view.
+        </p>
+        <Link href="/payroll" className="font-medium text-indigo-600 hover:underline">
+          Back to payroll
+        </Link>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Description

Added a payroll exception triage dashboard that groups exceptions by severity, source, and status, while keeping sensitive payroll values redacted. This fixes issue #262 by giving admins a single place to review blocking errors, warnings, and informational notices with clear next actions and filter controls.

Closes #262

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Setup/Infrastructure configuration

## How Has This Been Tested?

- [ ] Local manual testing (Please describe)
- [x] Unit/Integration Tests
- [ ] Verified on local Soroban/Stellar testnet

Ran:
- `npm exec vitest run __tests__/payroll-exceptions.test.tsx`

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] Local manual testing (Please describe)
- [x] Unit/Integration Tests
- [ ] Verified on local Soroban/Stellar testnet