### PR TITLE
feat: add search to payroll exception triage

### DIFF
--- a/__tests__/payroll-exceptions.test.tsx
+++ b/__tests__/payroll-exceptions.test.tsx
@@ -67,6 +67,17 @@ describe("PayrollExceptionsQueue", () => {
     expect(screen.queryByText(/settlement failed on trust line limit/i)).not.toBeInTheDocument();
   });
 
+  it("filters by search term", async () => {
+    const user = userEvent.setup();
+    render(<PayrollExceptionsQueue exceptions={TRIAGE_ITEMS} />);
+
+    await user.type(screen.getByLabelText(/search exceptions/i), "trust line");
+
+    expect(screen.getAllByRole("table")).toHaveLength(1);
+    expect(screen.getByText(/settlement failed on trust line limit/i)).toBeInTheDocument();
+    expect(screen.queryByText(/proof generation pending/i)).not.toBeInTheDocument();
+  });
+
   it("filters by source and status", async () => {
     const user = userEvent.setup();
     render(<PayrollExceptionsQueue exceptions={TRIAGE_ITEMS} />);

--- a/components/features/payroll/PayrollExceptionsQueue.tsx
+++ b/components/features/payroll/PayrollExceptionsQueue.tsx
@@ -144,10 +144,12 @@ export default function PayrollExceptionsQueue({
   const [severityFilter, setSeverityFilter] = useState<ExceptionSeverity | "all">("all");
   const [sourceFilter, setSourceFilter] = useState<ExceptionSource | "all">("all");
   const [statusFilter, setStatusFilter] = useState<ExceptionStatus | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
   const filtered = useMemo(
     () =>
       exceptions.filter((item) => {
+        const query = searchQuery.trim().toLowerCase();
         if (severityFilter !== "all" && item.severity !== severityFilter) {
           return false;
         }
@@ -157,9 +159,25 @@ export default function PayrollExceptionsQueue({
         if (statusFilter !== "all" && item.status !== statusFilter) {
           return false;
         }
+        if (query) {
+          const haystack = [
+            item.title,
+            item.summary,
+            item.runId,
+            item.nextAction,
+            item.redactedValueLabel,
+            SOURCE_LABELS[item.source],
+          ]
+            .join(" ")
+            .toLowerCase();
+
+          if (!haystack.includes(query)) {
+            return false;
+          }
+        }
         return true;
       }),
-    [exceptions, severityFilter, sourceFilter, statusFilter],
+    [exceptions, severityFilter, sourceFilter, statusFilter, searchQuery],
   );
 
   const grouped = useMemo(
@@ -237,6 +255,25 @@ export default function PayrollExceptionsQueue({
         </div>
 
         <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-sm md:col-span-3">
+            <span className="block text-xs font-medium uppercase tracking-wide text-gray-500">
+              Search
+            </span>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                aria-hidden
+              />
+              <input
+                aria-label="Search exceptions"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search by run, source, action, or redacted label"
+                className="w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm"
+              />
+            </div>
+          </label>
+
           <label className="space-y-1 text-sm">
             <span className="block text-xs font-medium uppercase tracking-wide text-gray-500">
               Severity


### PR DESCRIPTION
## Description

Added a search field to the payroll exception triage dashboard so admins can quickly find specific blocking, warning, or informational items by run, source, action, or redacted label. This is a follow-up to the original triage dashboard work for issue #262.
Closes #262 
**Closes:** #262
Continues work in https://github.com/zkpayroll/zk-payroll-dashboard/pull/272
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Setup/Infrastructure configuration

## How Has This Been Tested?

- [ ] Local manual testing (Please describe)
- [x] Unit/Integration Tests
- [ ] Verified on local Soroban/Stellar testnet

Ran:
- `npm exec vitest run __tests__/payroll-exceptions.test.tsx`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new linting warnings or TypeScript errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
